### PR TITLE
Group and context

### DIFF
--- a/Solutions/PowerShell.Commands/Commands/Base/SPOWebCmdlet.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOWebCmdlet.cs
@@ -8,6 +8,9 @@ namespace OfficeDevPnP.PowerShell.Commands
 {
     public class SPOWebCmdlet : SPOCmdlet
     {
+        private Web _selectedWeb = null;
+
+
         [Parameter(Mandatory = false)]
         public WebPipeBind Web = new WebPipeBind();
 
@@ -15,7 +18,11 @@ namespace OfficeDevPnP.PowerShell.Commands
         {
             get
             {
-                return GetWeb();
+                if(_selectedWeb == null)
+                {
+                    _selectedWeb = GetWeb();
+                }
+                return _selectedWeb;
             }
         }
 
@@ -50,13 +57,22 @@ namespace OfficeDevPnP.PowerShell.Commands
             {
                 if (SPOnlineConnection.CurrentConnection.Context.Url != SPOnlineConnection.CurrentConnection.Url)
                 {
-                    SPOnlineConnection.CurrentConnection.Context = this.ClientContext.Clone(SPOnlineConnection.CurrentConnection.Url);
+                    SPOnlineConnection.CurrentConnection.ResetContext();
+                    //SPOnlineConnection.CurrentConnection.Context = this.ClientContext.Clone(SPOnlineConnection.CurrentConnection.Url);
                 }
                 web = ClientContext.Web;
             }
 
 
             return web;
+        }
+
+        protected override void EndProcessing()
+        {
+            if (SPOnlineConnection.CurrentConnection.Context.Url != SPOnlineConnection.CurrentConnection.Url)
+            {
+                SPOnlineConnection.CurrentConnection.ResetContext();
+            }
         }
     }
 }

--- a/Solutions/PowerShell.Commands/Commands/Base/SPOWebCmdlet.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOWebCmdlet.cs
@@ -18,7 +18,7 @@ namespace OfficeDevPnP.PowerShell.Commands
         {
             get
             {
-                if(_selectedWeb == null)
+                if (_selectedWeb == null)
                 {
                     _selectedWeb = GetWeb();
                 }
@@ -57,7 +57,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             {
                 if (SPOnlineConnection.CurrentConnection.Context.Url != SPOnlineConnection.CurrentConnection.Url)
                 {
-                    SPOnlineConnection.CurrentConnection.ResetContext();
+                    SPOnlineConnection.CurrentConnection.RestoreCachedContext();
                     //SPOnlineConnection.CurrentConnection.Context = this.ClientContext.Clone(SPOnlineConnection.CurrentConnection.Url);
                 }
                 web = ClientContext.Web;
@@ -71,8 +71,14 @@ namespace OfficeDevPnP.PowerShell.Commands
         {
             if (SPOnlineConnection.CurrentConnection.Context.Url != SPOnlineConnection.CurrentConnection.Url)
             {
-                SPOnlineConnection.CurrentConnection.ResetContext();
+                SPOnlineConnection.CurrentConnection.RestoreCachedContext();
             }
         }
+
+        protected override void BeginProcessing()
+        {
+            SPOnlineConnection.CurrentConnection.CacheContext();
+        }
+
     }
 }

--- a/Solutions/PowerShell.Commands/Commands/Base/SPOnlineConnection.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOnlineConnection.cs
@@ -53,9 +53,14 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
             TenantAdmin = 2
         }
 
-        public void ResetContext()
+        public void RestoreCachedContext()
         {
             Context = _initialContext;
+        }
+
+        internal void CacheContext()
+        {
+            _initialContext = Context;
         }
     }
 }

--- a/Solutions/PowerShell.Commands/Commands/Base/SPOnlineConnection.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOnlineConnection.cs
@@ -6,6 +6,8 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
 {
     public class SPOnlineConnection
     {
+        private ClientContext _initialContext;
+
         internal static SPOnlineConnection CurrentConnection { get; set; }
         public ConnectionTypes ConnectionType { get; protected set; }
         public int MinimalHealthScore { get; protected set; }
@@ -35,6 +37,7 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
             if (context == null)
                 throw new ArgumentNullException("context");
             this.Context = context;
+            this._initialContext = context;
             this.ConnectionType = connectionType;
             this.MinimalHealthScore = minimalHealthScore;
             this.RetryCount = retryCount;
@@ -48,6 +51,11 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
             OnPrem = 0,
             O365 = 1,
             TenantAdmin = 2
+        }
+
+        public void ResetContext()
+        {
+            Context = _initialContext;
         }
     }
 }

--- a/Solutions/PowerShell.Commands/Commands/Enums/AssociatedGroupTypeEnum.cs
+++ b/Solutions/PowerShell.Commands/Commands/Enums/AssociatedGroupTypeEnum.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OfficeDevPnP.PowerShell.Commands.Enums
+{
+    public enum AssociatedGroupTypeEnum
+    {
+        None,
+        Visitors,
+        Members,
+        Owners
+    }
+}
+

--- a/Solutions/PowerShell.Commands/Commands/Extensions/WebExtensions.cs
+++ b/Solutions/PowerShell.Commands/Commands/Extensions/WebExtensions.cs
@@ -14,7 +14,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             var clientContext = currentWeb.Context as ClientContext;
             Site site = clientContext.Site;
             Web web = site.OpenWebById(guid);
-            clientContext.Load(web, w => w.Url);
+            clientContext.Load(web, w => w.Url, w => w.Title, w => w.Id);
             clientContext.ExecuteQuery();
 
             return web;
@@ -25,7 +25,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             var clientContext = currentWeb.Context as ClientContext;
             Site site = clientContext.Site;
             Web web = site.OpenWeb(url);
-            clientContext.Load(web, w => w.Url);
+            clientContext.Load(web, w => w.Url, w => w.Title, w => w.Id);
             clientContext.ExecuteQuery();
 
             return web;

--- a/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
+++ b/Solutions/PowerShell.Commands/Commands/OfficeDevPnP.PowerShell.Commands.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Admin\GetTenantSite.cs" />
     <Compile Include="ContentTypes\SetDefaultContentTypeToList.cs" />
     <Compile Include="ContentTypes\AddContentTypeToList.cs" />
+    <Compile Include="Enums\AssociatedGroupTypeEnum.cs" />
     <Compile Include="Extensions\ClientExtensions.cs" />
     <Compile Include="Extensions\ListExtensions.cs" />
     <Compile Include="ContentTypes\AddFieldToContentType.cs" />
@@ -189,6 +190,7 @@
     <Compile Include="Lists\RemoveView.cs" />
     <Compile Include="Lists\RemoveList.cs" />
     <Compile Include="Base\PipeBinds\ViewPipeBind.cs" />
+    <Compile Include="Principals\SetGroup.cs" />
     <Compile Include="Web\RemoveJavaScriptLink.cs" />
     <Compile Include="Web\AddJavaScriptLink.cs" />
     <Compile Include="Web\AddJavaScriptBlock.cs" />

--- a/Solutions/PowerShell.Commands/Commands/Principals/NewGroup.cs
+++ b/Solutions/PowerShell.Commands/Commands/Principals/NewGroup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.SharePoint.Client;
 using OfficeDevPnP.PowerShell.CmdletHelpAttributes;
 using OfficeDevPnP.PowerShell.Commands.Base;
+using OfficeDevPnP.PowerShell.Commands.Enums;
 using System.Management.Automation;
 
 namespace OfficeDevPnP.PowerShell.Commands.Principals
@@ -27,8 +28,8 @@ PS:> New-SPOUser -LogonName user@company.com
         [Parameter(Mandatory = false)]
         public SwitchParameter AutoAcceptRequestToJoinLeave;
 
-        [Parameter(Mandatory = false)]
-        public AssociatedGroupType SetAssociatedGroup = AssociatedGroupType.None;
+        [Parameter(Mandatory = false, DontShow=true)] // Not promoted to use anymore. Use Set-SPOGroup
+        public AssociatedGroupTypeEnum SetAssociatedGroup = AssociatedGroupTypeEnum.None;
 
         protected override void ExecuteCmdlet()
         {
@@ -55,17 +56,17 @@ PS:> New-SPOUser -LogonName user@company.com
                 group.AutoAcceptRequestToJoinLeave = true;
                 dirty = true;
             }
-            if(dirty)
+            if (dirty)
             {
                 group.Update();
                 ClientContext.ExecuteQuery();
             }
-           
+
 
             if (!string.IsNullOrEmpty(Owner))
             {
                 Principal groupOwner = null;
-             
+
                 try
                 {
                     groupOwner = web.EnsureUser(Owner);
@@ -83,21 +84,21 @@ PS:> New-SPOUser -LogonName user@company.com
             }
 
 
-            if (SetAssociatedGroup != AssociatedGroupType.None)
+            if (SetAssociatedGroup != AssociatedGroupTypeEnum.None)
             {
                 switch (SetAssociatedGroup)
                 {
-                    case AssociatedGroupType.Visitors:
+                    case AssociatedGroupTypeEnum.Visitors:
                         {
                             web.AssociateDefaultGroups(null, null, group);
                             break;
                         }
-                    case AssociatedGroupType.Members:
+                    case AssociatedGroupTypeEnum.Members:
                         {
                             web.AssociateDefaultGroups(null, group, null);
                             break;
                         }
-                    case AssociatedGroupType.Owners:
+                    case AssociatedGroupTypeEnum.Owners:
                         {
                             web.AssociateDefaultGroups(group, null, null);
                             break;
@@ -106,16 +107,6 @@ PS:> New-SPOUser -LogonName user@company.com
             }
             ClientContext.ExecuteQuery();
             WriteObject(group);
-
-
-        }
-
-        public enum AssociatedGroupType
-        {
-            None,
-            Visitors,
-            Members,
-            Owners
         }
     }
 }

--- a/Solutions/PowerShell.Commands/Commands/Principals/SetGroup.cs
+++ b/Solutions/PowerShell.Commands/Commands/Principals/SetGroup.cs
@@ -1,0 +1,94 @@
+﻿using OfficeDevPnP.PowerShell.Commands.Base.PipeBinds;
+using OfficeDevPnP.PowerShell.Commands.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SharePoint.Client;
+
+namespace OfficeDevPnP.PowerShell.Commands.Principals
+{
+    [Cmdlet("Set", "SPOGroup")]
+    public class SetGroup : SPOWebCmdlet
+    {
+        [Parameter(Mandatory=true)]
+        public GroupPipeBind Identity;
+
+        [Parameter(Mandatory = false)]
+        public AssociatedGroupTypeEnum SetAssociatedGroup = AssociatedGroupTypeEnum.None;
+
+        [Parameter(Mandatory = false)]
+        public string AddRole = string.Empty;
+
+        [Parameter(Mandatory = false)]
+        public string RemoveRole = string.Empty;
+
+        protected override void ExecuteCmdlet()
+        {
+            Group group = null;
+            if (Identity.Id != -1)
+            {
+                group = this.SelectedWeb.SiteGroups.GetById(Identity.Id);
+            }
+            else if (!string.IsNullOrEmpty(Identity.Name))
+            {
+                group = this.SelectedWeb.SiteGroups.GetByName(Identity.Name);
+            }
+            else if (Identity.Group != null)
+            {
+                group = Identity.Group;
+            }
+
+            if (SetAssociatedGroup != AssociatedGroupTypeEnum.None)
+            {
+                switch (SetAssociatedGroup)
+                {
+                    case AssociatedGroupTypeEnum.Visitors:
+                        {
+                            this.SelectedWeb.AssociateDefaultGroups(null, null, group);
+                            break;
+                        }
+                    case AssociatedGroupTypeEnum.Members:
+                        {
+                            this.SelectedWeb.AssociateDefaultGroups(null, group, null);
+                            break;
+                        }
+                    case AssociatedGroupTypeEnum.Owners:
+                        {
+                            this.SelectedWeb.AssociateDefaultGroups(group, null, null);
+                            break;
+                        }
+                }
+            }
+            if(!string.IsNullOrEmpty(AddRole))
+            {
+                var roleDefinition = this.SelectedWeb.RoleDefinitions.GetByName(AddRole);
+                var roleDefinitionBindings = new RoleDefinitionBindingCollection(ClientContext);
+                roleDefinitionBindings.Add(roleDefinition);
+                var roleAssignments = this.SelectedWeb.RoleAssignments;
+                roleAssignments.Add(group,roleDefinitionBindings);
+                ClientContext.Load(roleAssignments);
+                ClientContext.ExecuteQuery();
+            }
+            if(!string.IsNullOrEmpty(RemoveRole))
+            {
+                var roleAssignment = this.SelectedWeb.RoleAssignments.GetByPrincipal(group);
+                var roleDefinitionBindings = roleAssignment.RoleDefinitionBindings;
+                ClientContext.Load(roleDefinitionBindings);
+                ClientContext.ExecuteQuery();
+                foreach(var roleDefinition in roleDefinitionBindings)
+                {
+                    if(roleDefinition.Name == RemoveRole)
+                    {
+                        roleDefinitionBindings.Remove(roleDefinition);
+                        roleAssignment.Update();
+                        ClientContext.ExecuteQuery();
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Solutions/PowerShell.Commands/Commands/Web/GetWeb.cs
+++ b/Solutions/PowerShell.Commands/Commands/Web/GetWeb.cs
@@ -15,7 +15,7 @@ namespace OfficeDevPnP.PowerShell.Commands
         {
             if (Identity == null)
             {
-                ClientContext.Load(ClientContext.Web);
+                ClientContext.Load(ClientContext.Web, w => w.Id, w => w.Url, w => w.Title);
                 ClientContext.ExecuteQuery();
                 WriteObject(this.ClientContext.Web);
             }

--- a/Solutions/PowerShell.Commands/changelog.md
+++ b/Solutions/PowerShell.Commands/changelog.md
@@ -1,5 +1,9 @@
 # OfficeDevPnP.PowerShell Changelog #
 
+**2015-01-02**
+* Removed SetAssociatedGroup parameter from new-spogroup cmdlet and moved it to a separate cmdlet: Set-SPOGroup
+* Introduced new Cmdlet: Set-SPOGroup to set the group as an associated group and optionally add or remove role assignments
+
 **2014-12-30**
 * Changed New-SPOWeb to return the actual web as an object instead of a success message.
 * Added -SetAssociatedGroup parameter to New-SPOGroup to set a group as a default associated visitors, members or owners group

--- a/Solutions/PowerShell.Commands/readme.md
+++ b/Solutions/PowerShell.Commands/readme.md
@@ -149,6 +149,7 @@ Command | Description
 **New-SPOGroup** | Creates a group
 **New-SPOUser** | Adds a user to the Site User Info List. Equivalent to web.EnsureUser(user)
 **Remove-SPOUserFromGroup** | Removes a user from a group
+**Set-SPOGroup** | Sets a group as an associated group (Owners, Members, Visitors) or adds or removes a role assignment (e.g. "Contribute", "Read", etc.)
 
 #### Site Cmdlets ####
 Command | Description


### PR DESCRIPTION
Increased performance of cmdlets inheriting from SPOWebCmdlet
Introduced new Set-SPOGroup cmdlet
Deprecated -SetAssociatedGroup parameter on new-spogroup cmdlet. Moved the parameter to set-spogroup
Caches the initial context to restore after a SPOWebCmdlet with a -Web parameter is done executing. 