### PR TITLE
added AllowAllPageLayouts method (similar to SSOM)

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/BrandingExtensions.cs
@@ -973,6 +973,14 @@ namespace Microsoft.SharePoint.Client
             web.SetPropertyBagValue(AvailablePageLayouts, "");
         }
 
+        /// <summary>
+        /// Allow the web to use all available page layouts
+        /// </summary>
+        /// <param name="web"></param>
+        public static void AllowAllPageLayouts(this Web web)
+        {
+            ClearAvailablePageLayouts(web);
+        }
 
         public static void SetAvailablePageLayouts(this Web web, Web rootWeb, IEnumerable<string> pageLayouts)
         {


### PR DESCRIPTION
Added AllowAllPageLayouts method (similar to SSOM) which will allow all the page layouts to be used on the web. The ClearAvailablePageLayouts method can be used to achieve the same functionality but then the name of the method does not seem meaningful