### PR TITLE
Office365Api.Demo Updated to latest release of libraries

### DIFF
--- a/Samples/Office365Api.Overview/Office365Api.Demo/App.config
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/App.config
@@ -1,6 +1,43 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+  <appSettings>
+    <add key="ida:ClientId" value="a4a7005a-eb5c-49cc-a824-305e3ebce0bd" />
+    <add key="ida:RedirectUri" value="http://localhost/59695cc52584e2a28b4a6bd5faaf4eea" />
+    <add key="ida:AuthorizationUri" value="https://login.windows.net/" />
+  </appSettings>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.3.0" newVersion="5.6.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.9.0.0" newVersion="6.9.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.9.0.0" newVersion="6.9.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.9.0.0" newVersion="6.9.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.13.0.0" newVersion="2.13.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Samples/Office365Api.Overview/Office365Api.Demo/AuthenticationHelper.cs
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/AuthenticationHelper.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Office365.Discovery;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Office365Api.Demo
+{
+    public static class AuthenticationHelper
+    {
+        public static readonly string ClientId = ConfigurationManager.AppSettings["ida:ClientID"].ToString();
+        public static readonly string RedirectUri = ConfigurationManager.AppSettings["ida:RedirectUri"].ToString();
+
+        public static AuthenticationContext AuthenticationContext
+        {
+            get;
+            private set;
+        }
+
+        public static AuthenticationResult AuthenticationResult
+        {
+            get;
+            private set;
+        }
+
+        public static void Authenticate(String authority)
+        {
+            if (AuthenticationHelper.AuthenticationContext == null)
+            {
+                AuthenticationHelper.AuthenticationContext = new AuthenticationContext(authority);
+
+                var tokenCache = AuthenticationContext.TokenCache.ReadItems().FirstOrDefault();
+
+                if (tokenCache != null)
+                {
+                    AuthenticationHelper.AuthenticationContext = new AuthenticationContext(tokenCache.Authority);
+                }
+            }
+
+            AuthenticationHelper.AuthenticationResult =
+                AuthenticationHelper.AuthenticationContext.AcquireToken(
+                    Office365ServicesUris.AADGraphAPIResourceId, 
+                    ClientId, 
+                    new Uri(RedirectUri));
+        }
+
+        public static async Task<String> GetAccessTokenForServiceAsync(CapabilityDiscoveryResult discoveryCapabilityResult)
+        {
+            return await GetAccessTokenForServiceAsync(discoveryCapabilityResult.ServiceResourceId);
+        }
+
+        public static async Task<String> GetAccessTokenForServiceAsync(String serviceResourceId)
+        {
+            var authResult = await AuthenticationHelper.AuthenticationContext.AcquireTokenSilentAsync(serviceResourceId, ClientId);
+
+            return authResult.AccessToken;
+        }
+    }
+}

--- a/Samples/Office365Api.Overview/Office365Api.Demo/ContactsApiSample.cs
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/ContactsApiSample.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Office365.Exchange;
-using Microsoft.Office365.OAuth;
+﻿using Microsoft.Office365.OAuth;
+using Microsoft.Office365.OutlookServices;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,18 +10,6 @@ namespace Office365Api.Demo
 {
     public static class ContactsAPISample
     {
-        const string ServiceResourceId = "https://outlook.office365.com";
-        static readonly Uri ServiceEndpointUri = new Uri("https://outlook.office365.com/ews/odata");
-
-        // Do not make static in Web apps; store it in session or in a cookie instead
-        static string _lastLoggedInUser;
-        //static DiscoveryContext _discoveryContext;
-        public static DiscoveryContext _discoveryContext
-        {
-            get;
-            set;
-        }
-
         public static async Task<IEnumerable<IContact>> GetContacts()
         {
             var client = await EnsureClientCreated();
@@ -34,36 +22,20 @@ namespace Office365Api.Demo
             return contactsResults.CurrentPage;
         }
 
-        public static async Task<ExchangeClient> EnsureClientCreated()
+        public static async Task<OutlookServicesClient> EnsureClientCreated()
         {
-            if (_discoveryContext == null)
-            {
-                _discoveryContext = await DiscoveryContext.CreateAsync();
-            }
+            var discoveryResult = await DiscoveryAPISample.DiscoveryClient.DiscoverCapabilityAsync(Office365Capabilities.Contacts.ToString());
 
-            var dcr = await _discoveryContext.DiscoverResourceAsync(ServiceResourceId);
+            var ServiceResourceId = discoveryResult.ServiceResourceId;
+            var ServiceEndpointUri = discoveryResult.ServiceEndpointUri;
 
-            _lastLoggedInUser = dcr.UserId;
-
-            return new ExchangeClient(ServiceEndpointUri, async () =>
-            {
-                return (await _discoveryContext.AuthenticationContext.AcquireTokenSilentAsync(ServiceResourceId, _discoveryContext.AppIdentity.ClientId, new Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier(dcr.UserId, Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifierType.UniqueId))).AccessToken;
-            });
-        }
-
-        public static async Task SignOut()
-        {
-            if (string.IsNullOrEmpty(_lastLoggedInUser))
-            {
-                return;
-            }
-
-            if (_discoveryContext == null)
-            {
-                _discoveryContext = await DiscoveryContext.CreateAsync();
-            }
-
-            await _discoveryContext.LogoutAsync(_lastLoggedInUser);
+            // Create the OutlookServicesClient client proxy:
+            return new OutlookServicesClient(
+                ServiceEndpointUri,
+                async () =>
+                {
+                    return await AuthenticationHelper.GetAccessTokenForServiceAsync(discoveryResult);
+                });
         }
     }
 }

--- a/Samples/Office365Api.Overview/Office365Api.Demo/MailApiSample.cs
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/MailApiSample.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Office365.Exchange;
-using Microsoft.Office365.OAuth;
+﻿using Microsoft.Office365.OAuth;
+using Microsoft.Office365.OutlookServices;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,18 +10,6 @@ namespace Office365Api.Demo
 {
     public static class MailApiSample
     {
-        const string ServiceResourceId = "https://outlook.office365.com";
-        static readonly Uri ServiceEndpointUri = new Uri("https://outlook.office365.com/ews/odata");
-
-        // Do not make static in Web apps; store it in session or in a cookie instead
-        static string _lastLoggedInUser;
-        //static DiscoveryContext _discoveryContext;
-        public static DiscoveryContext _discoveryContext
-        {
-            get;
-            set;
-        }
- 
         public static async Task<IEnumerable<IMessage>> GetMessages()
         {
             var client = await EnsureClientCreated();
@@ -29,44 +17,44 @@ namespace Office365Api.Demo
 
             List<IMessage> mails = new List<IMessage>();
 
-            var query = from i in client.Me.Inbox.Messages
+            // ***********************************************************
+            // Note from @PaoloPia: To not stress the server, limit the
+            // the query to no more than 50 email items
+            // ***********************************************************
+
+            var query = (from i in client.Me.Messages
                         orderby i.DateTimeSent descending
-                        select i;
+                        select i).Take(50);
 
             var messageResults = await query.ExecuteAsync();
 
-            //Server side paging is currently broken
-            //do
-            //{
-            //    mails.AddRange(messageResults.CurrentPage);
-            //    messageResults = await messageResults.GetNextPageAsync();
-            //}
-            //while (messageResults != null);
-
-            //Resort to client side paging
-            while (true)
+            do
             {
-                int sizeBefore = mails.Count;
                 mails.AddRange(messageResults.CurrentPage);
-
-                if (mails.Count == sizeBefore)
-                {
-                    break;
-                }
-
-                messageResults = await query.Skip(mails.Count).ExecuteAsync();
+                messageResults = await messageResults.GetNextPageAsync();
             }
+            while (messageResults.MorePagesAvailable);
 
+            // ***********************************************************
+            // Note from @PaoloPia: The following sample code should 
+            // be removed because now server-side paging works properly
+            // ***********************************************************
+
+            ////Resort to client side paging
+            //while (true)
+            //{
+            //    int sizeBefore = mails.Count;
+            //    mails.AddRange(messageResults.CurrentPage);
+
+            //    if (mails.Count == sizeBefore)
+            //    {
+            //        break;
+            //    }
+
+            //    messageResults = await query.Skip(mails.Count).ExecuteAsync();
+            //}
 
             return mails;
-        }
-
-        public static async Task<int> GetMailStats()
-        {
-            var client = await EnsureClientCreated();
-
-            var inbox = await client.Me.Inbox.ExecuteAsync();
-            return (int)inbox.TotalCount;
         }
 
         public static async Task SendMail(string to, string subject, string body)
@@ -74,12 +62,17 @@ namespace Office365Api.Demo
             var client = await EnsureClientCreated();
 
             Message mail = new Message();
-            mail.ToRecipients.Add(new Recipient() { Address = to});
+            mail.ToRecipients.Add(new Recipient() 
+            {
+                EmailAddress = new EmailAddress
+                {
+                    Address = to,
+                }
+            });
             mail.Subject = subject;
             mail.Body = new ItemBody() { Content = body, ContentType = BodyType.HTML };
-            
-            await client.Me.SentItems.Messages.AddMessageAsync(mail);
-            await mail.SendAsync();
+
+            await client.Me.SendMailAsync(mail, true);
         }
 
         public static async Task DraftMail(string to, string subject, string body)
@@ -87,47 +80,33 @@ namespace Office365Api.Demo
             var client = await EnsureClientCreated();
 
             Message mail = new Message();
-            mail.ToRecipients.Add(new Recipient() { Address = to });
-            mail.Subject = subject;
-            mail.IsDraft = true;
-            mail.Body = new ItemBody() { Content = body, ContentType = BodyType.Text };
-
-            await client.Me.Drafts.Messages.AddMessageAsync(mail);
-        }
-
-        public static async Task<ExchangeClient> EnsureClientCreated()
-        {
-            if (_discoveryContext == null)
+            mail.ToRecipients.Add(new Recipient()
             {
-                _discoveryContext = await DiscoveryContext.CreateAsync();
-            }
-
-            var dcr = await _discoveryContext.DiscoverResourceAsync(ServiceResourceId);
-
-            _lastLoggedInUser = dcr.UserId;
-
-            return new ExchangeClient(ServiceEndpointUri, async () =>
-            {
-                return (await _discoveryContext.AuthenticationContext.AcquireTokenSilentAsync(ServiceResourceId, _discoveryContext.AppIdentity.ClientId, new Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifier(dcr.UserId, Microsoft.IdentityModel.Clients.ActiveDirectory.UserIdentifierType.UniqueId))).AccessToken;
+                EmailAddress = new EmailAddress
+                {
+                    Address = to,
+                }
             });
+            mail.Subject = subject;
+            mail.Body = new ItemBody() { Content = body, ContentType = BodyType.HTML };
+
+            await client.Me.Messages.AddMessageAsync(mail);
         }
 
-        public static async Task SignOut()
+        public static async Task<OutlookServicesClient> EnsureClientCreated()
         {
-            if (string.IsNullOrEmpty(_lastLoggedInUser))
-            {
-                return;
-            }
+            var discoveryResult = await DiscoveryAPISample.DiscoveryClient.DiscoverCapabilityAsync(Office365Capabilities.Mail.ToString());
 
-            if (_discoveryContext == null)
-            {
-                _discoveryContext = await DiscoveryContext.CreateAsync();
-            }
+            var ServiceResourceId = discoveryResult.ServiceResourceId;
+            var ServiceEndpointUri = discoveryResult.ServiceEndpointUri;
 
-            await _discoveryContext.LogoutAsync(_lastLoggedInUser);
+            // Create the OutlookServicesClient client proxy:
+            return new OutlookServicesClient(
+                ServiceEndpointUri,
+                async () =>
+                {
+                    return await AuthenticationHelper.GetAccessTokenForServiceAsync(discoveryResult);
+                });
         }
-
-
-
     }
 }

--- a/Samples/Office365Api.Overview/Office365Api.Demo/MainWindow.xaml
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/MainWindow.xaml
@@ -4,11 +4,39 @@
         Title="Office 365 API Demo" Height="800" Width="1000">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="34"/>
+            <RowDefinition Height="200"/>
+            <RowDefinition Height="50"/>
             <RowDefinition Height="285*"/>
         </Grid.RowDefinitions>
-        <Button x:Name="btnGo" Content="Run demo" Margin="10,4" Click="Button_Click"/>
-        <ScrollViewer x:Name="scrollViewerOutput" Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" LayoutUpdated="ScrollViewer_LayoutUpdated">
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="300" />
+                <ColumnDefinition Width="700*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="40"/>
+                <RowDefinition Height="40"/>
+            </Grid.RowDefinitions>
+            <Label Grid.Row="0" Grid.Column="0" Content="Authority:" FontSize="16" VerticalAlignment="Center" Margin="10,0" />
+            <TextBox Name="Authority" Grid.Row="0" Grid.Column="1" Text="https://login.windows.net/Common/" FontSize="16" VerticalAlignment="Center" />
+            <Label Grid.Row="1" Grid.Column="0" Content="SharePoint Online Tenant URI:" FontSize="16" VerticalAlignment="Center" Margin="10,0" />
+            <TextBox Name="SharePointTenantUri" Grid.Row="1" Grid.Column="1" Text="https://piasysdev.sharepoint.com/" FontSize="16" VerticalAlignment="Center" />
+            <Label Grid.Row="2" Grid.Column="0" Content="SharePoint Online SiteCollection:" FontSize="16" VerticalAlignment="Center" Margin="10,0" />
+            <TextBox Name="SiteCollectionUri" Grid.Row="2" Grid.Column="1" Text="https://piasysdev.sharepoint.com/sites/20150107/" FontSize="16" VerticalAlignment="Center" />
+            <Label Grid.Row="3" Grid.Column="0" Content="Mail To Address:" FontSize="16" VerticalAlignment="Center" Margin="10,0" />
+            <TextBox Name="MailAddressTo" Grid.Row="3" Grid.Column="1" Text="paolo@pialorsi.com" FontSize="16" VerticalAlignment="Center" />
+            <Label Grid.Row="4" Grid.Column="0" Content="File to Upload:" FontSize="16" VerticalAlignment="Center" Margin="10,0" />
+            <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal">
+                <TextBox Name="FileToUploadPath" Text="" FontSize="16" VerticalAlignment="Center" Width="600" IsReadOnly="True" />
+                <Label Content="" />
+                <Button Name="BrowseFileToUploadPath" Content="..." FontSize="16" VerticalAlignment="Center" Width="40" Height="25" Click="BrowseFileToUploadPath_Click" />
+            </StackPanel>
+        </Grid>
+        <Button x:Name="btnGo" Content="Run demo" Grid.Row="1" Margin="10,4" FontSize="16" Click="Button_Click"/>
+        <ScrollViewer x:Name="scrollViewerOutput" Grid.Row="2" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" LayoutUpdated="ScrollViewer_LayoutUpdated">
             <TextBlock x:Name="txtOutput" Grid.Row="1" TextWrapping="NoWrap" FontSize="18" FontFamily="Consolas" Margin="0" Padding="10,10,0,0"/>
         </ScrollViewer>
     </Grid>

--- a/Samples/Office365Api.Overview/Office365Api.Demo/Office365Api.Demo.csproj
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/Office365Api.Demo.csproj
@@ -34,60 +34,73 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
+      <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.3\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Edm.5.6.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Data.OData, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.OData.5.6.1\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.1\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.7.10707.1513-rc\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.13.112191810\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.7.10707.1513-rc\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.13.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.13.112191810\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client">
-      <HintPath>..\packages\Microsoft.OData.Client.6.3.0\lib\net40\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=6.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.OData.Client.6.9.0\lib\net40\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Core">
-      <HintPath>..\packages\Microsoft.OData.Core.6.3.0\lib\portable-net40+sl5+wp8+win8\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=6.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.OData.Core.6.9.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm">
-      <HintPath>..\packages\Microsoft.OData.Edm.6.3.0\lib\portable-net40+sl5+wp8+win8\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=6.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.OData.Edm.6.9.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office365.ActiveDirectory">
-      <HintPath>..\packages\Microsoft.Office365.UsersGroups.0.1.1-alpha\lib\net40\Microsoft.Office365.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.Office365.Discovery">
+      <HintPath>..\packages\Microsoft.Office365.Discovery.1.0.22\lib\portable-net40+sl5+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Office365.Discovery.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office365.Exchange">
-      <HintPath>..\packages\Microsoft.Office365.Exchange.0.1.1-alpha\lib\net40\Microsoft.Office365.Exchange.dll</HintPath>
+    <Reference Include="Microsoft.Office365.OAuth, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Office365.OAuth.Windows.1.0.22\lib\net45\Microsoft.Office365.OAuth.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office365.OAuth">
-      <HintPath>..\packages\Microsoft.Office365.OAuth.Windows.0.1.1-alpha\lib\net45\Microsoft.Office365.OAuth.dll</HintPath>
+    <Reference Include="Microsoft.Office365.OAuth.WindowsForms, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Office365.OAuth.Windows.1.0.22\lib\net45\Microsoft.Office365.OAuth.WindowsForms.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office365.OAuth.WindowsForms">
-      <HintPath>..\packages\Microsoft.Office365.OAuth.Windows.0.1.1-alpha\lib\net45\Microsoft.Office365.OAuth.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.Office365.OutlookServices">
+      <HintPath>..\packages\Microsoft.Office365.OutlookServices.1.0.22\lib\net40\Microsoft.Office365.OutlookServices.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office365.SharePoint">
-      <HintPath>..\packages\Microsoft.Office365.MyFiles.0.1.1-alpha\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
+    <Reference Include="Microsoft.Office365.SharePoint, Version=1.0.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Office365.SharePoint.1.0.22\lib\net40\Microsoft.Office365.SharePoint.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial">
-      <HintPath>..\packages\Microsoft.Spatial.6.3.0\lib\portable-net40+sl5+wp8+win8\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=6.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Spatial.6.9.0\lib\portable-net40+sl5+wp8+win8+wpa\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Spatial, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Spatial, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Spatial.5.6.1\lib\net40\System.Spatial.dll</HintPath>
+      <HintPath>..\packages\System.Spatial.5.6.3\lib\net40\System.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -117,11 +130,14 @@
       </SubType>
     </Compile>
     <Compile Include="DiscoveryAPISample.cs" />
+    <Compile Include="AuthenticationHelper.cs" />
     <Compile Include="MailApiSample.cs">
       <ConnectedServiceReference>Users and Groups</ConnectedServiceReference>
       <SubType>
       </SubType>
     </Compile>
+    <Compile Include="Office365Capabilities.cs" />
+    <Compile Include="Office365ServicesUris.cs" />
     <Compile Include="SitesApiSample.cs">
       <ConnectedServiceReference>Users and Groups</ConnectedServiceReference>
       <SubType>

--- a/Samples/Office365Api.Overview/Office365Api.Demo/Office365Capabilities.cs
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/Office365Capabilities.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Office365Api.Demo
+{
+    public enum Office365Capabilities
+    {
+        Mail,
+        Calendar,
+        Contacts,
+        MyFiles,
+    }
+}

--- a/Samples/Office365Api.Overview/Office365Api.Demo/Office365ServicesUris.cs
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/Office365ServicesUris.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Office365Api.Demo
+{
+    public static class Office365ServicesUris
+    {
+        public static readonly Uri DiscoveryServiceEndpointUri = new Uri("https://api.office.com/discovery/v1.0/me/");
+
+        public static readonly string DiscoveryServiceResourceId = "https://api.office.com/discovery/";
+
+        public static readonly string AADGraphAPIResourceId = "https://graph.windows.net";
+    }
+}

--- a/Samples/Office365Api.Overview/Office365Api.Demo/packages.config
+++ b/Samples/Office365Api.Overview/Office365Api.Demo/packages.config
@@ -1,17 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.7.10707.1513-rc" targetFramework="net45" />
-  <package id="Microsoft.OData.Client" version="6.3.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="6.3.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.3.0" targetFramework="net45" />
-  <package id="Microsoft.Office365.Exchange" version="0.1.1-alpha" targetFramework="net45" />
-  <package id="Microsoft.Office365.MyFiles" version="0.1.1-alpha" targetFramework="net45" />
-  <package id="Microsoft.Office365.OAuth.Windows" version="0.1.1-alpha" targetFramework="net45" />
-  <package id="Microsoft.Office365.UsersGroups" version="0.1.1-alpha" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.3.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.13.112191810" targetFramework="net45" />
+  <package id="Microsoft.OData.Client" version="6.9.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="6.9.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="6.9.0" targetFramework="net45" />
+  <package id="Microsoft.Office365.Discovery" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Office365.OAuth.Windows" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Office365.OutlookServices" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Office365.SharePoint" version="1.0.22" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="6.9.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.7" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
 </packages>

--- a/Samples/Office365Api.Overview/readme.md
+++ b/Samples/Office365Api.Overview/readme.md
@@ -45,17 +45,17 @@ For these tasks to succeed you need to provide some input before you run the app
 ## Run the sample ##
 When you run the sample you'll see some text fields, a window with a big button named "Run demo" and a black output section. Fill out the text fields with proper values, select a file to upload by browsing the file system, and click on the "Run demo" button to trigger the demo. What will first happen is that you need to logon with an Office 365 user account.
 
-![](http://i.imgur.com/RIGgm7H.png)
+![](http://i.imgur.com/852IH4o.png)
 
 
 Once you've logged on the Office 365 API will ask you for permissions: you need to consent that the app access your data for the listed categories:
 
-![](http://i.imgur.com/6bDBl5w.png)
+![](http://i.imgur.com/M9D343S.png)
 
 
 After those 2 steps are done the app can run and use all the API's to do it's work. The output is shown in console style:
 
-![](http://i.imgur.com/LQnkq5W.png)
+![](http://i.imgur.com/vLcdlrL.png)
 
 ## Some explanation about the API's themselves ##
 The app is built by extending the default classes added when you hookup a connected service:

--- a/Samples/Office365Api.Overview/readme.md
+++ b/Samples/Office365Api.Overview/readme.md
@@ -1,22 +1,24 @@
-# Office 365 API demo application (PREVIEW) #
+# Office 365 API demo application #
 
 ### Summary ###
-This WPF app show the output of various Office 365 API calls in a console alike output format. The goal of this app is the see the new API while keeping focus on the API calls themselves and less on the UI layer they're hosted in.
+This WPF app show the output of various Office 365 API calls in a console alike output format. The goal of this app is to see the new API while keeping focus on the API calls themselves and less on the UI layer they're hosted in.
 
 ### Applies to ###
 -  Office 365 Multi Tenant (MT)
 
 ### Prerequisites ###
-This sample requires the Office 365 API **preview** version released on August 5th 2014. See http://blogs.office.com/2014/08/05/office-365-api-tool-visual-studio-2013-summer-update/ for more details.
+This sample requires the Office 365 API version released on November 2014. See http://msdn.microsoft.com/en-us/office/office365/howto/platform-development-overview for more details.
 
 ### Solution ###
-Solution | Author(s)
----------|----------
-Office365Api.Overview | Bert Jansen (**Microsoft**)
+Solution | Author(s)|Twitter
+---------|----------|----------
+Office365Api.Overview | Bert Jansen (**Microsoft**) |
+Office365Api.Overview | Paolo Pialorsi (**PiaSys.com**) | @PaoloPia
 
 ### Version history ###
 Version  | Date | Comments
 ---------| -----| --------
+3.0  | January 7th 2015 | Updated to Office 365 API RTM and ADAL 2.13.*
 2.0  | August 12th 2014 | Switched to WPF app and added documentation
 1.0  | July 29th 2014 | Initial release
 
@@ -33,22 +35,15 @@ This application will use the new Office 365 API's to perform the following list
 -  List the files and folders from the user's OneDrive
 -  Upload a file to the "Shared with everyone" folder in the user's OneDrive
 -  List all files and folders in the "Shared with everyone" folder of the user's OneDrive
--  List the total number of mails in the user's mailbox
--  Retrieve all mails in the Inbox, just print the first 10
+-  Retrieve top 50 mails in the Inbox, just print the first 10
 -  Send a mail with the sent mail ending up in the user's "Sent items" mailbox folder
 -  Create a mail in the "Drafts" mailbox folder
 -  Get all users from Azure AD, just print the first 10
 
-For these tasks to succeed you need to provide some input before you run the application. This is done by changing the below code snippet in the MainWindow.xaml.cs class:
-```C#
-//TODO: update these values to make them relevant for your environment
-private string uploadFile = @"C:\temp\bulkadusers.xlsx";
-private string serviceResourceId = "https://<tenant>.sharepoint.com";
-private string siteUrl = "https://<tenant>.sharepoint.com/sites/<sitename>";
-private string sendMailTo = "<email address>";
-```
+For these tasks to succeed you need to provide some input before you run the application. This is done by changing the text fields in the UI, just after launching the WPF project.
+
 ## Run the sample ##
-When you run the sample you'll see a window with a big button named "Run demo" and a black output section. Click on the "Run demo" button to trigger the demo. What will first happen is that you need to logon with an Office 365 user account.
+When you run the sample you'll see some text fields, a window with a big button named "Run demo" and a black output section. Fill out the text fields with proper values, select a file to upload by browsing the file system, and click on the "Run demo" button to trigger the demo. What will first happen is that you need to logon with an Office 365 user account.
 
 ![](http://i.imgur.com/RIGgm7H.png)
 
@@ -63,7 +58,7 @@ After those 2 steps are done the app can run and use all the API's to do it's wo
 ![](http://i.imgur.com/LQnkq5W.png)
 
 ## Some explanation about the API's themselves ##
-The app is built by extending the default classess added when you hookup a connected service:
+The app is built by extending the default classes added when you hookup a connected service:
 -  ActiveDirectoryApiSample.cs
 -  CalendarApiSample.cs
 -  ContactsApiSample.cs
@@ -71,14 +66,4 @@ The app is built by extending the default classess added when you hookup a conne
 -  MyFilesApiSample.cs
 -  SitesApiSample.cs
 
-The class DiscoveryAPISample.cs has been created manually. The default classes have been adopted to so that they can pass along the DiscoveryContext created during the first use. This is needed to avoid continues prompting for consent.
-
-```C#
-//static DiscoveryContext _discoveryContext;
-public static DiscoveryContext _discoveryContext
-{
-    get;
-    set;
-}
-
-```
+The class DiscoveryAPISample.cs has been created manually, as well as the AuthenticationHelper.cs class. Those classes have been adopted in order to share and cache the AuthenticationContext created during the first logon. This is needed to avoid continues prompting for consent.


### PR DESCRIPTION
Guys,
I've update the sample to the latest libraries (Office 365 API .NET Client Library, ADAL and AD GraphClient).
However, there are some issues that we need to share and fix/decide how to handle.

Bert,
Please take a look at my comments in the code. You can find them by searching the "Note from @PaoloPia" trailer.

So far, the issues are:
1) MailApiSample: I can't find any method to get mail stats, as like as it was in the beta version of the libraries. Maybe it is my fault, maybe the PG removed that capability. Can you check it against the PG? I can't find anything anymore in the online docs on MSDN/Office Dev about mail stats.
2) MailApiSample: I removed the client-side paging, because now the server-side paging works properly. Do you agree?
3) SitesApiSample: the Site Collection files query doesn't work. I fighted against it more than two hours (!) ... but no win! :( Can you try to have a look at the failing call, which is highlighted with an IMPORTANT comment, and which is commented out of the MainWindow.xaml.cs code. Thanks.
4) I placed some query limits for emails and files, to not overload the Office 365 servers and the network in case of a huge number of items to download. I hope you agree.

After committing this demo, I'm planning to move to an ASP.NET MVC demo, as well. I think it would be really useful to have both the scenarios (native/desktop app versus web application). Can I? Do you agree?

Thanks,
Paolo