### PR TITLE
Added search ContentType in SiteHierarchy option while adding ContentType to list

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -558,10 +558,12 @@ namespace Microsoft.SharePoint.Client
         /// <param name="listTitle">Title of the list</param>
         /// <param name="contentTypeID">Complete ID for the content type</param>
         /// <param name="defaultContent">Optionally make this the default content type</param>
-        public static void AddContentTypeToListById(this Web web, string listTitle, string contentTypeId, bool defaultContent = false)
+        /// <param name="searchContentTypeInSiteHierarchy">search for content type in site hierarchy</param>
+        public static void AddContentTypeToListById(this Web web, string listTitle, string contentTypeId, bool defaultContent = false, bool searchContentTypeInSiteHierarchy = false)
         {
             // Get content type instance
-            ContentType contentType = GetContentTypeById(web, contentTypeId);
+            ContentType contentType = GetContentTypeById(web, contentTypeId, searchContentTypeInSiteHierarchy);
+
             // Add content type to list
             AddContentTypeToList(web, listTitle, contentType, defaultContent);
         }
@@ -573,10 +575,12 @@ namespace Microsoft.SharePoint.Client
         /// <param name="listTitle">Title of the list</param>
         /// <param name="contentTypeName">Name of the content type</param>
         /// <param name="defaultContent">Optionally make this the default content type</param>
-        public static void AddContentTypeToListByName(this Web web, string listTitle, string contentTypeName, bool defaultContent = false)
+        /// <param name="searchContentTypeInSiteHierarchy">search for content type in site hierarchy</param>
+        public static void AddContentTypeToListByName(this Web web, string listTitle, string contentTypeName, bool defaultContent = false, bool searchContentTypeInSiteHierarchy = false)
         {
             // Get content type instance
-            ContentType contentType = GetContentTypeByName(web, contentTypeName);
+            ContentType contentType = GetContentTypeByName(web, contentTypeName, searchContentTypeInSiteHierarchy);
+
             // Add content type to list
             AddContentTypeToList(web, listTitle, contentType, defaultContent);
         }
@@ -592,6 +596,7 @@ namespace Microsoft.SharePoint.Client
         {
             // Get list instances
             List list = web.GetListByTitle(listTitle);
+
             // Add content type to list
             AddContentTypeToList(list, contentType, defaultContent);
         }
@@ -602,10 +607,11 @@ namespace Microsoft.SharePoint.Client
         /// <param name="list">List to add content type to</param>
         /// <param name="contentTypeID">Complete ID for the content type</param>
         /// <param name="defaultContent">If set true, content type is updated to be default content type for the list</param>
-        public static void AddContentTypeToListById(this List list, string contentTypeID, bool defaultContent = false)
+        /// <param name="searchContentTypeInSiteHierarchy">search for content type in site hierarchy</param>
+        public static void AddContentTypeToListById(this List list, string contentTypeID, bool defaultContent = false, bool searchContentTypeInSiteHierarchy = false)
         {
             Web web = list.ParentWeb;
-            ContentType contentType = GetContentTypeById(web, contentTypeID);
+            ContentType contentType = GetContentTypeById(web, contentTypeID, searchContentTypeInSiteHierarchy);
             AddContentTypeToList(list, contentType, defaultContent);
         }
 
@@ -615,10 +621,11 @@ namespace Microsoft.SharePoint.Client
         /// <param name="list">List to add content type to</param>
         /// <param name="contentTypeName">Name of the content type</param>
         /// <param name="defaultContent">If set true, content type is updated to be default content type for the list</param>
-        public static void AddContentTypeToListByName(this List list, string contentTypeName, bool defaultContent = false)
+        /// <param name="searchContentTypeInSiteHierarchy">search for content type in site hierarchy</param>
+        public static void AddContentTypeToListByName(this List list, string contentTypeName, bool defaultContent = false, bool searchContentTypeInSiteHierarchy = false)
         {
             Web web = list.ParentWeb;
-            ContentType contentType = GetContentTypeByName(web, contentTypeName);
+            ContentType contentType = GetContentTypeByName(web, contentTypeName, searchContentTypeInSiteHierarchy);
             AddContentTypeToList(list, contentType, defaultContent);
         }
 
@@ -714,13 +721,13 @@ namespace Microsoft.SharePoint.Client
                 propertyLoadRequired = true;
             }
 
-            if(!contentType.IsPropertyAvailable("FieldLinks"))
+            if (!contentType.IsPropertyAvailable("FieldLinks"))
             {
                 web.Context.Load(contentType.FieldLinks);
                 propertyLoadRequired = true;
             }
 
-            if(propertyLoadRequired)
+            if (propertyLoadRequired)
             {
                 web.Context.ExecuteQuery();
             }
@@ -1299,7 +1306,7 @@ namespace Microsoft.SharePoint.Client
             //Casting throws "Specified method is not supported" when using in v15
             //var ctCol = listContentTypes.Cast<ContentType>().ToList();
             List<ContentType> ctCol = new List<ContentType>();
-            foreach(ContentType ct in listContentTypes)
+            foreach (ContentType ct in listContentTypes)
             {
                 ctCol.Add(ct);
             }


### PR DESCRIPTION
In the scenarios, where we have ContentType defined at root site and want to use it in a list exist at the sub-site, the option to search ContentType in SiteHierarchy will be helpful.