### PR TITLE
Changed reference for AppForSharePointWebToolkit

### DIFF
--- a/Samples/Core.JavaScriptInjection.WeekNumbers/Core.JavaScriptInjection.WeekNumbersWeb/packages.config
+++ b/Samples/Core.JavaScriptInjection.WeekNumbers/Core.JavaScriptInjection.WeekNumbersWeb/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/Scenarios/Core.Services.Authenticate/Core.Services.Authenticate.SharePointWeb/packages.config
+++ b/Scenarios/Core.Services.Authenticate/Core.Services.Authenticate.SharePointWeb/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />

--- a/Solutions/Core.ConnectedSigRAngularJSAppParts/Core.ConnectedSigRAngularJSAppPartsWeb/packages.config
+++ b/Solutions/Core.ConnectedSigRAngularJSAppParts/Core.ConnectedSigRAngularJSAppPartsWeb/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.SignalR.Client" version="2.1.2" targetFramework="net45" />

--- a/Solutions/OD4B.Configuration.Async/OD4B.Configuration.AsyncWeb/packages.config
+++ b/Solutions/OD4B.Configuration.Async/OD4B.Configuration.AsyncWeb/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AppForSharePoint16WebToolkit" version="3.0.1" targetFramework="net45" />
+  <package id="AppForSharePointWebToolkit" version="3.0.1" targetFramework="net45" />
   <package id="jQuery" version="1.9.1" targetFramework="net45" />
   <package id="Microsoft.Data.Edm" version="5.6.2" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.6.2" targetFramework="net45" />


### PR DESCRIPTION
According to guidance there shouldn't be a reference in packages to AppForSharePoint16WebToolkit instead AppForSharePointWebToolkit.

Read more here: https://github.com/OfficeDev/PnP/blob/master/Guidance/ConfigSpPHAppsForDistro.md
 