### PR TITLE
Fix alignment of dialog and overlay in taxonomypicker component/sample

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
@@ -40,18 +40,18 @@
 }
 
 .cam-taxpicker-dialog-overlay {
-    position: absolute;
+    position: fixed;
     left: 0px;
     right: 0px;
     top: 0px;
-    bottom: 0px;
+    height: 100%;
     background-color: #999;
     opacity: 0.4;
     z-index: 1500;
 }
 
 .cam-taxpicker-dialog-content {
-    position: absolute;
+    position: fixed;
     width: 820px;
     height: 650px;
     left: 50%;

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
@@ -26,18 +26,18 @@
 }
 
 .cam-taxpicker-dialog-overlay {
-    position: absolute;
+    position: fixed;
     left: 0px;
     right: 0px;
     top: 0px;
-    bottom: 0px;
+    height: 100%;
     background-color: #999;
     opacity: 0.4;
     z-index: 1500;
 }
 
 .cam-taxpicker-dialog-content {
-    position: absolute;
+    position: fixed;
     width: 820px;
     height: 650px;
     left: 50%;


### PR DESCRIPTION
When opening dialog and overlay on a page with more than 1 screen of content
the artefakts did not align. Replaced absolute positioning with fixed.

Tested on IE11 and Firefox 36.0a2