### PR TITLE
Taxonomy fix

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -642,8 +642,8 @@ namespace Microsoft.SharePoint.Client
                     string termName;
                     if (subTermItem.IndexOf(";#", StringComparison.Ordinal) > -1)
                     {
-                        termName = subTermItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
-                        termId = new Guid(subTermItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
+                        termName = subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[0];
+                        termId = new Guid(subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[1]);
                     }
                     else
                     {
@@ -681,6 +681,10 @@ namespace Microsoft.SharePoint.Client
                             termStore.CommitAll();
                             clientContext.ExecuteQuery();
                         }
+                        term = subTerm;
+                    }
+                    else
+                    {
                         term = subTerm;
                     }
                 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -407,8 +407,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="termLines"></param>
         /// <param name="lcid"></param>
         /// <param name="delimiter"></param>
-        /// <param name="overwriteExisting"></param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|", bool overwriteExisting = false)
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|")
         {
             termLines.ValidateNotNullOrEmpty("termLines");
 
@@ -417,7 +416,7 @@ namespace Microsoft.SharePoint.Client
             TaxonomySession taxonomySession = TaxonomySession.GetTaxonomySession(clientContext);
             TermStore termStore = taxonomySession.GetDefaultSiteCollectionTermStore();
 
-            ImportTerms(site, termLines, lcid, termStore, delimiter, overwriteExisting);
+            ImportTerms(site, termLines, lcid, termStore, delimiter);
         }
 
         /// <summary>
@@ -432,11 +431,10 @@ namespace Microsoft.SharePoint.Client
         /// <param name="lcid"></param>
         /// <param name="termStore">The termstore to import the terms into</param>
         /// <param name="delimiter"></param>
-        /// <param name="overwriteExisting">Overwrites existing tags if already existing</param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|", bool overwriteExisting=false)
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|")
         {
             var groupCache = new List<TermGroup>();
-            var setCache = new List<TermGroup>();
+            var setCache = new List<TermSet>();
             termLines.ValidateNotNullOrEmpty("termLines");
             termStore.ValidateNotNullOrEmpty("termStore");
 
@@ -448,15 +446,16 @@ namespace Microsoft.SharePoint.Client
             }
             clientContext.Load(termStore);
             clientContext.ExecuteQuery();
-            foreach (string line in termLines)
+            foreach (var line in termLines)
             {
                 // split up
-                string[] items = line.Split(new string[] { delimiter }, StringSplitOptions.None);
-                if (items.Any())
+                var items = line.Split(new string[] { delimiter }, StringSplitOptions.None);
+                if (items.Any()) // *TermGroup*|TermSet|Term
                 {
-                    string groupItem = items[0];
-                    string groupName = groupItem;
-                    Guid groupId = Guid.Empty;
+                    var groupItem = items[0];
+                    var groupName = groupItem;
+                    var groupId = Guid.Empty;
+
                     if (groupItem.IndexOf(";#", StringComparison.Ordinal) > -1)
                     {
                         groupName = groupItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
@@ -465,9 +464,9 @@ namespace Microsoft.SharePoint.Client
                     TermGroup termGroup = null;
 
                     // Cached?
-                    if(groupCache.Any())
+                    if (groupCache.Any())
                     {
-                        if(groupId != Guid.Empty)
+                        if (groupId != Guid.Empty)
                         {
                             termGroup = groupCache.FirstOrDefault(tg => tg.Id == groupId);
                         }
@@ -508,11 +507,11 @@ namespace Microsoft.SharePoint.Client
                         clientContext.Load(termGroup);
                         clientContext.ExecuteQuery();
                         groupCache.Add(termGroup);
-                            
+
                     }
-                    if (items.Count() > 1)
+                    if (items.Count() > 1)  // TermGroup|*TermSet*|Term
                     {
-                        // TermSet
+                        // TermSets
                         if (termGroup.ServerObjectIsNull == false)
                         {
                             var termsetItem = items[1];
@@ -524,20 +523,33 @@ namespace Microsoft.SharePoint.Client
                                 termsetId = new Guid(termsetItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
                             }
                             TermSet termSet = null;
-                            if (termsetId != Guid.Empty)
+                            if (setCache.Any())
                             {
-                                termSet = termGroup.TermSets.GetById(termsetId);
+                                if (termsetId != Guid.Empty)
+                                {
+                                    termSet = setCache.FirstOrDefault(ts => ts.Id == termsetId);
+                                }
                             }
-                            else
+                            if (termSet == null)
                             {
-                                termSet = termGroup.TermSets.GetByName(NormalizeName(termsetName));
+                                if (termsetId != Guid.Empty)
+                                {
+                                    termSet = termGroup.TermSets.GetById(termsetId);
+                                }
+                                else
+                                {
+                                    termSet = termGroup.TermSets.GetByName(NormalizeName(termsetName));
+                                }
+                                clientContext.Load(termSet);
+                                try
+                                {
+                                    clientContext.ExecuteQuery();
+                                    setCache.Add(termSet);
+                                }
+                                catch
+                                {
+                                }
                             }
-                            clientContext.Load(termSet);
-                            try
-                            {
-                                clientContext.ExecuteQuery();
-                            }
-                            catch { }
                             if (termSet.ServerObjectIsNull == null)
                             {
                                 if (termsetId == Guid.Empty)
@@ -547,119 +559,92 @@ namespace Microsoft.SharePoint.Client
                                 termSet = termGroup.CreateTermSet(NormalizeName(termsetName), termsetId, lcid);
                                 clientContext.Load(termSet);
                                 clientContext.ExecuteQuery();
+                                setCache.Add(termSet);
                             }
-                            if (items.Count() > 2)
+                            if (items.Count() > 2) // TermGroup|TermSet|*Term*
                             {
                                 // Term(s)
 
                                 if (termSet.ServerObjectIsNull == false)
                                 {
-                                    string termItem = items[2];
-                                    string termName = termItem;
-                                    Guid termId = Guid.Empty;
-                                    if (termItem.IndexOf(";#", StringComparison.Ordinal) > -1)
-                                    {
-                                        termName = termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
-                                        termId = new Guid(termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
-                                    }
-                                    Term term = null;
-                                    if (termId != Guid.Empty)
-                                    {
-                                        term = termSet.Terms.GetById(termId);
-                                    }
-                                    else
-                                    {
-                                        term = termSet.Terms.GetByName(NormalizeName(termName));
-                                    }
-                                    clientContext.Load(term, t => t.Name, t => t.Id, t => t.Terms);
-                                    try
-                                    {
-                                        clientContext.ExecuteQuery();
-                                    }
-                                    catch { }
-                                    if (term.ServerObjectIsNull == null)
-                                    {
-                                        if(termId == Guid.Empty)
-                                        {
-                                            termId = Guid.NewGuid();
-                                        }
-                                        term = termSet.CreateTerm(NormalizeName(termName), lcid, termId);
-                                        clientContext.ExecuteQuery();
-                                    } else if (overwriteExisting && term.ServerObjectIsNull == false)
-                                    {
-                                        if (term.Name != termName)
-                                        {
-                                            term.Name = termName;
-                                            termStore.CommitAll();
-                                            clientContext.ExecuteQuery();
-                                        }
-                                    }
-
-                                    if (items.Count() > 3)
-                                    {
-                                        clientContext.Load(term, t => t.Id, t => t.Name, t => t.Terms);
-                                        clientContext.ExecuteQuery();
-                                        if (term.ServerObjectIsNull == false)
-                                        {
-                                            for (var q = 3; q < items.Count(); q++)
-                                            {
-                                                var subTermItem = items[q];
-                                                termId = Guid.Empty;
-                                                if (subTermItem.IndexOf(";#", StringComparison.Ordinal) > -1)
-                                                {
-                                                    termName =
-                                                        subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[
-                                                            0];
-                                                    termId =
-                                                        new Guid(
-                                                            subTermItem.Split(new string[] {";#"},
-                                                                StringSplitOptions.None)[1]);
-                                                }
-                                                else
-                                                {
-                                                    termName = subTermItem;
-                                                }
-                                                Term subTerm = null;
-                                                if (termId != Guid.Empty)
-                                                {
-                                                    subTerm = term.Terms.GetById(termId);
-                                                }
-                                                else
-                                                {
-                                                    subTerm = term.Terms.GetByName(NormalizeName(termName));
-                                                }
-                                                clientContext.Load(term);
-                                                try
-                                                {
-                                                    clientContext.ExecuteQuery();
-                                                }
-                                                catch
-                                                {
-                                                }
-                                                if (subTerm.ServerObjectIsNull == null)
-                                                {
-                                                    term = term.AddTermToTerm(lcid, termName, termId);
-                                                }
-                                                else if (overwriteExisting && subTerm.ServerObjectIsNull == false)
-                                                {
-                                                    clientContext.Load(subTerm, t => t.Id, t => t.Name, t => t.Terms);
-                                                    clientContext.ExecuteQuery();
-
-                                                    if (subTerm.Name != termName)
-                                                    {
-                                                        subTerm.Name = termName;
-                                                        termStore.CommitAll();
-                                                        clientContext.ExecuteQuery();
-                                                    }
-                                                    term = subTerm;
-                                                }
-                                            }
-                                        }
-                                    }
+                                    ParseTerms(lcid, items, termSet, clientContext);
                                 }
                             }
                         }
                     }
+                }
+            }
+        }
+
+        private static void ParseTerms(int lcid, string[] items, TermSet termSet, ClientRuntimeContext clientContext)
+        {
+            var termItem = items[2];
+            var termName = termItem;
+            var termId = Guid.Empty;
+            if (termItem.IndexOf(";#", StringComparison.Ordinal) > -1)
+            {
+                termName = termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
+                termId = new Guid(termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
+            }
+            Term term = null;
+            if (termId != Guid.Empty)
+            {
+                term = termSet.Terms.GetById(termId);
+            }
+            else
+            {
+                term = termSet.Terms.GetByName(NormalizeName(termName));
+            }
+            clientContext.Load(term);
+            try
+            {
+                clientContext.ExecuteQuery();
+            }
+            catch
+            {
+            }
+            if (term.ServerObjectIsNull == null)
+            {
+                if (termId == Guid.Empty)
+                {
+                    termId = Guid.NewGuid();
+                }
+                term = termSet.CreateTerm(NormalizeName(termName), lcid, termId);
+                clientContext.ExecuteQuery();
+            }
+
+            if (items.Count() > 3)  // TermGroup|TermSet|Term|*SubTerm*
+            {
+                ParseSubTerms(lcid, clientContext, term, items, termItem);
+            }
+        }
+
+        private static void ParseSubTerms(int lcid, ClientRuntimeContext clientContext, Term term, string[] items, string termItem)
+        {
+            clientContext.Load(term);
+            clientContext.ExecuteQuery();
+            if (term.ServerObjectIsNull == false)
+            {
+                for (var q = 3; q < items.Count(); q++)
+                {
+                    var subTermItem = items[q];
+                    var termId = Guid.Empty;
+                    string termName;
+                    if (termItem.IndexOf(";#", StringComparison.Ordinal) > -1)
+                    {
+                        termName =
+                            subTermItem.Split(new string[] { ";#" }, StringSplitOptions.None)[
+                                0];
+                        termId =
+                            new Guid(
+                                subTermItem.Split(new string[] { ";#" },
+                                    StringSplitOptions.None)[1]);
+                    }
+                    else
+                    {
+                        termName = subTermItem;
+                    }
+                    term = term.AddTermToTerm(lcid, termName, termId);
                 }
             }
         }
@@ -1553,7 +1538,7 @@ namespace Microsoft.SharePoint.Client
             fieldCreationInformation.DisplayName.ValidateNotNullOrEmpty("displayName");
             fieldCreationInformation.TaxonomyItem.ValidateNotNullOrEmpty("taxonomyItem");
 
-            if(fieldCreationInformation.Id == Guid.Empty)
+            if (fieldCreationInformation.Id == Guid.Empty)
             {
                 fieldCreationInformation.Id = Guid.NewGuid();
             }
@@ -1609,8 +1594,8 @@ namespace Microsoft.SharePoint.Client
             fieldCreationInformation.TaxonomyItem.ValidateNotNullOrEmpty("taxonomyItem");
 
             if (fieldCreationInformation.Id == Guid.Empty)
-            { 
-                fieldCreationInformation.Id = Guid.NewGuid(); 
+            {
+                fieldCreationInformation.Id = Guid.NewGuid();
             }
             try
             {

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -407,7 +407,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="termLines"></param>
         /// <param name="lcid"></param>
         /// <param name="delimiter"></param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|")
+        /// <param name="overwriteExisting"></param>
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|", bool overwriteExisting = false)
         {
             termLines.ValidateNotNullOrEmpty("termLines");
 
@@ -416,7 +417,7 @@ namespace Microsoft.SharePoint.Client
             TaxonomySession taxonomySession = TaxonomySession.GetTaxonomySession(clientContext);
             TermStore termStore = taxonomySession.GetDefaultSiteCollectionTermStore();
 
-            ImportTerms(site, termLines, lcid, termStore, delimiter);
+            ImportTerms(site, termLines, lcid, termStore, delimiter, overwriteExisting);
         }
 
         /// <summary>
@@ -431,7 +432,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="lcid"></param>
         /// <param name="termStore">The termstore to import the terms into</param>
         /// <param name="delimiter"></param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|")
+        /// <param name="overwriteExisting">Overwrites existing tags if already existing</param>
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|", bool overwriteExisting=false)
         {
             var groupCache = new List<TermGroup>();
             var setCache = new List<TermGroup>();
@@ -513,10 +515,10 @@ namespace Microsoft.SharePoint.Client
                         // TermSet
                         if (termGroup.ServerObjectIsNull == false)
                         {
-                            string termsetItem = items[1];
-                            string termsetName = termsetItem;
-                            Guid termsetId = Guid.Empty;
-                            if (termsetItem.IndexOf(";#") > -1)
+                            var termsetItem = items[1];
+                            var termsetName = termsetItem;
+                            var termsetId = Guid.Empty;
+                            if (termsetItem.IndexOf(";#", StringComparison.Ordinal) > -1)
                             {
                                 termsetName = termsetItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
                                 termsetId = new Guid(termsetItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
@@ -569,7 +571,7 @@ namespace Microsoft.SharePoint.Client
                                     {
                                         term = termSet.Terms.GetByName(NormalizeName(termName));
                                     }
-                                    clientContext.Load(term);
+                                    clientContext.Load(term, t => t.Name, t => t.Id, t => t.Terms);
                                     try
                                     {
                                         clientContext.ExecuteQuery();
@@ -583,11 +585,19 @@ namespace Microsoft.SharePoint.Client
                                         }
                                         term = termSet.CreateTerm(NormalizeName(termName), lcid, termId);
                                         clientContext.ExecuteQuery();
+                                    } else if (overwriteExisting && term.ServerObjectIsNull == false)
+                                    {
+                                        if (term.Name != termName)
+                                        {
+                                            term.Name = termName;
+                                            termStore.CommitAll();
+                                            clientContext.ExecuteQuery();
+                                        }
                                     }
 
                                     if (items.Count() > 3)
                                     {
-                                        clientContext.Load(term);
+                                        clientContext.Load(term, t => t.Id, t => t.Name, t => t.Terms);
                                         clientContext.ExecuteQuery();
                                         if (term.ServerObjectIsNull == false)
                                         {
@@ -595,7 +605,7 @@ namespace Microsoft.SharePoint.Client
                                             {
                                                 var subTermItem = items[q];
                                                 termId = Guid.Empty;
-                                                if (termItem.IndexOf(";#", StringComparison.Ordinal) > -1)
+                                                if (subTermItem.IndexOf(";#", StringComparison.Ordinal) > -1)
                                                 {
                                                     termName =
                                                         subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[
@@ -609,7 +619,40 @@ namespace Microsoft.SharePoint.Client
                                                 {
                                                     termName = subTermItem;
                                                 }
-                                                term = term.AddTermToTerm(lcid, termName, termId);
+                                                Term subTerm = null;
+                                                if (termId != Guid.Empty)
+                                                {
+                                                    subTerm = term.Terms.GetById(termId);
+                                                }
+                                                else
+                                                {
+                                                    subTerm = term.Terms.GetByName(NormalizeName(termName));
+                                                }
+                                                clientContext.Load(term);
+                                                try
+                                                {
+                                                    clientContext.ExecuteQuery();
+                                                }
+                                                catch
+                                                {
+                                                }
+                                                if (subTerm.ServerObjectIsNull == null)
+                                                {
+                                                    term = term.AddTermToTerm(lcid, termName, termId);
+                                                }
+                                                else if (overwriteExisting && subTerm.ServerObjectIsNull == false)
+                                                {
+                                                    clientContext.Load(subTerm, t => t.Id, t => t.Name, t => t.Terms);
+                                                    clientContext.ExecuteQuery();
+
+                                                    if (subTerm.Name != termName)
+                                                    {
+                                                        subTerm.Name = termName;
+                                                        termStore.CommitAll();
+                                                        clientContext.ExecuteQuery();
+                                                    }
+                                                    term = subTerm;
+                                                }
                                             }
                                         }
                                     }

--- a/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
+++ b/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
@@ -32,6 +32,10 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public string Delimiter = "|";
 
+        [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
+        public SwitchParameter
+            Force;
+
         protected override void ExecuteCmdlet()
         {
             string[] lines = null;
@@ -47,11 +51,11 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
             {
                 var taxSession = TaxonomySession.GetTaxonomySession(ClientContext);
                 var termStore = taxSession.TermStores.GetByName(TermStoreName);
-                ClientContext.Site.ImportTerms(lines, LCID, termStore, Delimiter);
+                ClientContext.Site.ImportTerms(lines, LCID, termStore, Delimiter,Force);
             }
             else
             {
-                ClientContext.Site.ImportTerms(lines, LCID, Delimiter);
+                ClientContext.Site.ImportTerms(lines, LCID, Delimiter, Force);
             }
         }
 


### PR DESCRIPTION
Fixed errors causing incorrect imports when using ImportTerms
Changed some of the internal logic
Allow for overwriting existing terms (preventing 'Cannot read of write from database' cryptic error message)
Refactored in several methods for easier maintenance
Added internal cacheing which provides faster imports and less server requests.