### PR TITLE
Updated AzureAD.GroupMembership to use new Graph API 2.0

### DIFF
--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/App.config
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/App.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="TenantName" value="tenantname.onmicrosoft.com"/>
-    <add key="AzureADClientId" value="client id"/>
-    <add key="AzureADClientSecret" value="client secret"/>
+    <add key="TenantUpnDomain" value="onebitdev2015.onmicrosoft.com"/>
+    <add key="ClientId" value="GUID HERE"/>
+    <add key="ClientSecret" value="SECRET HERE"/>
   </appSettings>
   <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/App.config
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/App.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="TenantUpnDomain" value="onebitdev2015.onmicrosoft.com"/>
-    <add key="ClientId" value="GUID HERE"/>
-    <add key="ClientSecret" value="SECRET HERE"/>
+    <add key="TenantUpnDomain" value="TENANT.onmicrosoft.com"/>
+    <add key="ClientId" value="ENTER HERE"/>
+    <add key="ClientSecret" value="ENTER HERE"/>
   </appSettings>
   <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAD.GroupMembership.Console.csproj
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAD.GroupMembership.Console.csproj
@@ -33,13 +33,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient">
-      <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.1.0.3\lib\net40\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.0.3\lib\portable-net40+wp8+win8+MonoAndroid10+MonoTouch10+WindowsPhoneApp81\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Edm.5.6.3\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.OData.5.6.3\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Data.Services.Client.5.6.3\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.11.10918.1222\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.11.10918.1222\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -48,6 +60,10 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\System.Spatial.5.6.3\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -55,6 +71,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AzureAdAuthentication.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAD.GroupMembership.Console.csproj
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAD.GroupMembership.Console.csproj
@@ -53,9 +53,8 @@
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.14.201151115\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -76,7 +75,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAdAuthentication.cs
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/AzureAdAuthentication.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Azure.ActiveDirectory.GraphClient;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureAD.GroupMembership
+{
+    public static class AzureAdAuthentication
+    {
+        private const string AzureAdTenantLoginUrl = "https://login.windows.net/";
+        private const string GraphApiUrl = "https://graph.windows.net";
+
+        public static ActiveDirectoryClient GetActiveDirectoryClientAsApplication(Uri sharePointAdminUrl)
+        {
+            Uri servicePointUri = new Uri("");
+            string adminRealm = "";
+            Uri serviceRoot = new Uri(servicePointUri, adminRealm);
+
+            ActiveDirectoryClient activeDirectoryClient = new ActiveDirectoryClient(serviceRoot,
+                async () => await AcquireApplicationTokenAsync());
+            return activeDirectoryClient;
+        } 
+
+        public static async Task<string> AcquireApplicationTokenAsync()
+        {
+            var authenticationUrl = AzureAdTenantLoginUrl + ConfigurationManager.AppSettings["TenantUpnDomain"];
+            AuthenticationContext authenticationContext = new AuthenticationContext(authenticationUrl, false);
+
+            // Config for OAuth client credentials 
+            ClientCredential clientCred = new ClientCredential(
+                ConfigurationManager.AppSettings["ClientId"],
+                ConfigurationManager.AppSettings["ClientSecret"]);
+
+            AuthenticationResult authenticationResult = authenticationContext.AcquireToken(
+                GraphApiUrl,
+                clientCred);
+
+            string token = authenticationResult.AccessToken;
+            return token;
+        }
+    }
+}

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/Program.cs
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/Program.cs
@@ -16,21 +16,8 @@ namespace AzureAD.GroupMembership
         {
             try
             {
-                // get OAuth token using Client Credentials
-                string authString = "https://login.windows.net/" + ConfigurationManager.AppSettings["TenantName"];
-                AuthenticationContext authenticationContext = new AuthenticationContext(authString, false);
-
-                // Config for OAuth client credentials 
-                ClientCredential clientCred = new ClientCredential(ConfigurationManager.AppSettings["AzureADClientId"], ConfigurationManager.AppSettings["AzureADClientSecret"]);
-                string resource = "https://graph.windows.net";
-                string token = String.Empty;
-
-                // Authenticate
-                AuthenticationResult authenticationResult = authenticationContext.AcquireToken(resource, clientCred);
-                token = authenticationResult.AccessToken;
-
                 // setup Graph connection
-                GraphConnection graphConnection = SetupGraphConnection(token);
+                GraphConnection graphConnection = SetupGraphConnection("");
 
                 // Check group memberships. Pass along UPN of user and displayname of 
                 // the group to be checked. API support checking multiple groups at once

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/packages.config
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/packages.config
@@ -6,6 +6,6 @@
   <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.14.201151115" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
 </packages>

--- a/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/packages.config
+++ b/Samples/AzureAD.GroupMembership/AzureAD.GroupMembership.Console/packages.config
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="1.0.3" targetFramework="net45" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.11.10918.1222" targetFramework="net45" />
+  <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.0.3" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.3" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.14.201151115" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.3" targetFramework="net45" />
 </packages>

--- a/Samples/AzureAD.GroupMembership/readme.md
+++ b/Samples/AzureAD.GroupMembership/readme.md
@@ -1,27 +1,36 @@
 # Using the Azure AD Graph API to check group membership #
 
 ### Summary ###
-This sample shows how you can use the Azure AD Graph API to check if a given user is member of a group.
+This sample shows how you can use the Azure AD Graph API to check if a given user is member of a group. 
+
+You can find a few other useful samples in the code:
+- how to get all groups
+- how to get all users
+- how to list all groups that a user belongs to
 
 ### Applies to ###
 -  Office 365 Multi Tenant (MT)
--  Office 365 Dedicated (D)
--  SharePoint 2013 on-premises
-
 
 ### Prerequisites ###
+Option 1:
 -  Azures subscription with Azure AD setup
 -  Registration of an app in Azure AD is needed to make this sample work
+
+Option 2:
+-  Registering your ClientId and ClientSecret with SPO appregnew.aspx
+-  Giving permission through the Windows PowerShell Azure AD Module
 
 ### Solution ###
 Solution | Author(s)
 ---------|----------
 AzureAD.GroupMembership | Bert Jansen (**Microsoft**)
+AzureAD.GroupMembership | Radi Atanassov (**OneBit Software**)
 
 ### Version history ###
 Version  | Date | Comments
 ---------| -----| --------
 1.0  | October 7th 2014 | Initial release
+2.0  | January 19th 2015 | Updated to Graph API 2.0; Updated code with more samples; Added documentation option without an Azure subscription.
 
 ### Disclaimer ###
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**
@@ -36,7 +45,13 @@ The use case for this sample is showing how you can leverage your AD information
 
 An example use to leverage the Azure AD could be a provisioning app that depending on the group membership of a user provisions a site collection using additional elements.
 
-# Setup #
+# Configuration Options #
+Version 1.0 (and setup Option 1) was released with a configuration option that uses the Azure Management Portal to register the Application ID. You need an Azure subscription for the management portal - something you do not get with Office 365. (You can always register a trial subscription if you haven't already.)
+
+While version 2.0 updates the codebase to use the Graph API 2.0, the setup for Option 2 illustrates an alternative approach to register your application with Azure AD. Instead of using the Azure Management Portal, SPO's appregnew.aspx page is used and you **do not** need an Azure subscription.
+
+
+# Setup (Option 1) #
 Before you can use this sampe you'll first need to do a number of setup tasks.
 
 ## Ensure you've an Azure AD ##
@@ -70,9 +85,65 @@ Update the app.config file with the client ID and secret you've obtained in the 
 
 ```XML
   <appSettings>
-    <add key="TenantName" value="<tenantname>.onmicrosoft.com"/>
-    <add key="AzureADClientId" value="<client id>"/>
-    <add key="AzureADClientSecret" value="<client secret>"/>
+    <add key="TenantUpnName" value="<tenantname>.onmicrosoft.com"/>
+    <add key="ClientId" value="<client id>"/>
+    <add key="ClientSecret" value="<client secret>"/>
   </appSettings>
 ```
 
+# Setup (Option 2) #
+Option 1 and Option 2 achieve the same thing - you register an App with Azure AD. 
+- you need to do this so Azure AD can authenticate your app with OAuth (instead of user names and passwords)
+- Option 2 doesn't use the Azure Management Portal, it shows how you can do this without an Azure subscription (just using Office 365 and whatever you get with it)
+
+This is valid when you (or your client) just has Office 365 and no Azure.
+
+## Register ClientId & ClientSecret ##
+Given that the sample is a console app, Visual Studio will not register a ClientId/Secret and put them in the web.config for you.
+You need to do this yourself. In a production environment you don't even have Visual Studio, this is how you would deploy this in production.
+
+Start by getting and registering a ClientId and ClientSecret through /_layouts/15/AppRegNew.aspx:
+[](http://i.imgur.com/IznipPJ.png)
+Put a useful 'Title'. I use "localhost" for the App Domain and "https://localhost" for the Redirect UI. In the case of a console app you don't need niether of those.
+
+When you click 'Create', this form will do some magic - it will register a service principal with Azure AD (check it with Get-MsolServicePrincipal).
+
+Make sure you save/copy the values so you can plug them in the web.config.
+
+## Give your ClientId access to read Azure AD ##
+If you have done the above, you have actually registered your app (your ClientId) with the Azure AD instance behind Office 365. Although it is registered, it still doesn't have permissions to read the directory. 
+
+Using the Azure AD PowerShell module (get it from [http://msdn.microsoft.com/en-us/library/azure/jj151815.aspx](http://msdn.microsoft.com/en-us/library/azure/jj151815.aspx)) run this script after you plug in your ClientId:
+
+```PowerShell
+## Connect to the Microsoft Online tenant
+Connect-MsolService
+
+## Set the app Client Id, aka AppPrincipalId, in a variable
+$appId = "9a329aa2-01de-4248-8dc4-3187ed7e1c6c"
+
+## get the App Service Principal
+$appPrincipal = Get-MsolServicePrincipal -AppPrincipalId $appId 
+
+## Get the Directory Readers Role
+$directoryReaderRole = Get-MsolRole -RoleName "Directory Readers" ##get the role you want to set
+
+##Give the app the Directory Reader role
+Add-MsolRoleMember -RoleMemberType ServicePrincipal -RoleObjectId $directoryReaderRole.ObjectId -RoleMemberObjectId $appPrincipal.ObjectId
+
+##Confirm that the role has our app
+Get-MsolRoleMember -RoleObjectId $directoryReaderRole.ObjectId
+```
+
+This PowerShell script gets the Service Principal of the app, then gives it the "Directory Readers" permission. This is enough to get the users and their data.
+
+## Update the app.config file ##
+Update the app.config file with the client ID and secret you've obtained in the "appregnew.aspx" step & specify your tenant upn address.
+
+```XML
+  <appSettings>
+    <add key="TenantUpnName" value="<tenantname>.onmicrosoft.com"/>
+    <add key="ClientId" value="<client id>"/>
+    <add key="ClientSecret" value="<client secret>"/>
+  </appSettings>
+```


### PR DESCRIPTION
I have done a few things:
- updated the references to the new API 2.0
- removed the usage of GraphConnection and replaced with ActiveDirectoryClient
- added a few more samples that get the top 5 users and check for group membership
- provided a second option to get this working without the need for Azure portal subscriptions
