### PR TITLE
Taxonomy import fixes

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TaxonomyExtensions.cs
@@ -407,8 +407,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="termLines"></param>
         /// <param name="lcid"></param>
         /// <param name="delimiter"></param>
-        /// <param name="overwriteExisting"></param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|", bool overwriteExisting = false)
+        /// <param name="synchronizeDeletions">Remove tags that are not present in the import</param>
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, string delimiter = "|", bool synchronizeDeletions = false)
         {
             termLines.ValidateNotNullOrEmpty("termLines");
 
@@ -417,7 +417,7 @@ namespace Microsoft.SharePoint.Client
             TaxonomySession taxonomySession = TaxonomySession.GetTaxonomySession(clientContext);
             TermStore termStore = taxonomySession.GetDefaultSiteCollectionTermStore();
 
-            ImportTerms(site, termLines, lcid, termStore, delimiter, overwriteExisting);
+            ImportTerms(site, termLines, lcid, termStore, delimiter, synchronizeDeletions);
         }
 
         /// <summary>
@@ -432,13 +432,10 @@ namespace Microsoft.SharePoint.Client
         /// <param name="lcid"></param>
         /// <param name="termStore">The termstore to import the terms into</param>
         /// <param name="delimiter"></param>
-        /// <param name="overwriteExisting">Overwrites existing tags if already existing</param>
-        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|", bool overwriteExisting = false)
+        /// <param name="synchronizeDeletions">Remove tags that are not present in the import</param>
+        public static void ImportTerms(this Site site, string[] termLines, int lcid, TermStore termStore, string delimiter = "|", bool synchronizeDeletions = false)
         {
-            var groupCache = new List<TermGroup>();
-            var setCache = new List<TermSet>();
-            termLines.ValidateNotNullOrEmpty("termLines");
-            termStore.ValidateNotNullOrEmpty("termStore");
+            var groupDict = new Dictionary<TermGroup, List<string>>();
 
             var clientContext = site.Context;
             if (termStore.ServerObjectIsNull == true)
@@ -448,32 +445,44 @@ namespace Microsoft.SharePoint.Client
             }
             clientContext.Load(termStore);
             clientContext.ExecuteQuery();
-            foreach (string line in termLines)
+
+            foreach (var line in termLines)
             {
-                // split up
-                var items = line.Split(new string[] { delimiter }, StringSplitOptions.None);
+                // Find termgroup
+                var items = line.Split(new[] { delimiter }, StringSplitOptions.None);
                 if (items.Any())
                 {
+
+
+                    List<string> terms = null;
+
                     var groupItem = items[0];
                     var groupName = groupItem;
                     var groupId = Guid.Empty;
                     if (groupItem.IndexOf(";#", StringComparison.Ordinal) > -1)
                     {
-                        groupName = groupItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
-                        groupId = new Guid(groupItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
+                        groupName = groupItem.Split(new[] { ";#" }, StringSplitOptions.None)[0];
+                        groupId = new Guid(groupItem.Split(new[] { ";#" }, StringSplitOptions.None)[1]);
                     }
                     TermGroup termGroup = null;
-
                     // Cached?
-                    if (groupCache.Any())
+                    if (groupDict.Any())
                     {
+                        KeyValuePair<TermGroup, List<string>> groupDictItem;
                         if (groupId != Guid.Empty)
                         {
-                            termGroup = groupCache.FirstOrDefault(tg => tg.Id == groupId);
+                            groupDictItem = groupDict.FirstOrDefault(tg => tg.Key.Id == groupId);
+
+                            termGroup = groupDictItem.Key;
+                            terms = groupDictItem.Value;
+
                         }
                         else
                         {
-                            termGroup = groupCache.FirstOrDefault(tg => tg.Name == NormalizeName(groupName));
+                            groupDictItem = groupDict.FirstOrDefault(tg => tg.Key.Name == groupName);
+
+                            termGroup = groupDictItem.Key;
+                            terms = groupDictItem.Value;
                         }
                     }
                     if (termGroup == null)
@@ -491,7 +500,8 @@ namespace Microsoft.SharePoint.Client
                         {
                             clientContext.Load(termGroup);
                             clientContext.ExecuteQuery();
-                            groupCache.Add(termGroup);
+                            groupDict.Add(termGroup, new List<string>());
+                            terms = new List<string>();
                         }
                         catch
                         {
@@ -505,191 +515,64 @@ namespace Microsoft.SharePoint.Client
                             groupId = Guid.NewGuid();
                         }
                         termGroup = termStore.CreateGroup(NormalizeName(groupName), groupId);
+                        terms = new List<string>();
                         clientContext.Load(termGroup);
                         clientContext.ExecuteQuery();
-                        groupCache.Add(termGroup);
+
+                        groupDict.Add(termGroup, new List<string>());
 
                     }
-                    if (items.Count() > 1)
+                    var sb = new StringBuilder();
+                    if (items.Length > 1)
                     {
-                        // TermSet
-                        if (termGroup.ServerObjectIsNull == false)
-                        {
-                            var termsetItem = items[1];
-                            var termsetName = termsetItem;
-                            var termsetId = Guid.Empty;
-                            if (termsetItem.IndexOf(";#", StringComparison.Ordinal) > -1)
-                            {
-                                termsetName = termsetItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
-                                termsetId = new Guid(termsetItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
-                            }
-                            TermSet termSet = null;
-                            if (setCache.Any())
-                            {
-                                if (termsetId != Guid.Empty)
-                                {
-                                    termSet = setCache.FirstOrDefault(ts => ts.Id == termsetId);
-                                }
-                            }
-                            if (termSet == null)
-                            {
-                                if (termsetId != Guid.Empty)
-                                {
-                                    termSet = termGroup.TermSets.GetById(termsetId);
-                                }
-                                else
-                                {
-                                    termSet = termGroup.TermSets.GetByName(NormalizeName(termsetName));
-                                }
-                                clientContext.Load(termSet);
-                                try
-                                {
-                                    clientContext.ExecuteQuery();
-                                    setCache.Add(termSet);
-                                }
-                                catch
-                                {
-                                }
-                            }
-                            if (termSet.ServerObjectIsNull == null)
-                            {
-                                if (termsetId == Guid.Empty)
-                                {
-                                    termsetId = Guid.NewGuid();
-                                }
-                                termSet = termGroup.CreateTermSet(NormalizeName(termsetName), termsetId, lcid);
-                                clientContext.Load(termSet);
-                                clientContext.ExecuteQuery();
-                                setCache.Add(termSet);
-                            }
-                            if (items.Count() > 2)
-                            {
-                                // Term(s)
+                        var termSetName = items[1];
+                        termSetName = termSetName.Replace(";#", "|");
+                        sb.AppendFormat("{0},,{1},True,,", termSetName, lcid);
 
-                                if (termSet.ServerObjectIsNull == false)
-                                {
-                                    ParseTerms(lcid, termStore, overwriteExisting, items, termSet, clientContext);
-                                }
+                        // Termset = position 1
+                        for (var q = 0; q < 7; q++)
+                        {
+                            var item = "";
+                            if (items.Length > q + 2)
+                            {
+                                item = items[q + 2];
+                                item = item.Replace(";#", "|");
                             }
+                            sb.AppendFormat("{0},", item);
+                        }
+                        if (terms != null)
+                        {
+                            terms.Add(sb.ToString());
+
+                            groupDict[termGroup] = terms;
                         }
                     }
                 }
             }
-        }
+            foreach (var groupDictItem in groupDict)
+            {
+                var memoryStream = new MemoryStream();
 
-        private static void ParseTerms(int lcid, TermStore termStore, bool overwriteExisting, string[] items, TermSet termSet, ClientRuntimeContext clientContext)
-        {
-            var termItem = items[2];
-            var termName = termItem;
-            var termId = Guid.Empty;
-            if (termItem.IndexOf(";#", StringComparison.Ordinal) > -1)
-            {
-                termName = termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[0];
-                termId = new Guid(termItem.Split(new string[] { ";#" }, StringSplitOptions.None)[1]);
-            }
-            Term term = null;
-            if (termId != Guid.Empty)
-            {
-                term = termSet.Terms.GetById(termId);
-            }
-            else
-            {
-                term = termSet.Terms.GetByName(NormalizeName(termName));
-            }
-            clientContext.Load(term, t => t.Name, t => t.Id, t => t.Terms);
-            try
-            {
-                clientContext.ExecuteQuery();
-            }
-            catch
-            {
-            }
-            if (term.ServerObjectIsNull == null)
-            {
-                if (termId == Guid.Empty)
+                var termGroup = groupDictItem.Key as TermGroup;
+                using (var streamWriter = new StreamWriter(memoryStream))
                 {
-                    termId = Guid.NewGuid();
-                }
-                term = termSet.CreateTerm(NormalizeName(termName), lcid, termId);
-                clientContext.ExecuteQuery();
-            }
-            else if (overwriteExisting && term.ServerObjectIsNull == false)
-            {
-                if (term.Name != termName)
-                {
-                    term.Name = termName;
-                    termStore.CommitAll();
-                    clientContext.ExecuteQuery();
-                }
-            }
+                    // Header
+                    streamWriter.WriteLine(@"""Term Set Name"",""Term Set Description"",""LCID"",""Available for Tagging"",""Term Description"",""Level 1 Term"",""Level 2 Term"",""Level 3 Term"",""Level 4 Term"",""Level 5 Term"",""Level 6 Term"",""Level 7 Term""");
 
-            if (items.Count() > 3)
-            {
-                ParseSubTerms(lcid, termStore, overwriteExisting, clientContext, term, items);
+                    // Items
+                    foreach (var termLine in groupDictItem.Value)
+                    {
+                        streamWriter.WriteLine(termLine);
+                    }
+                    streamWriter.Flush();
+                    memoryStream.Position = 0;
+                    termGroup.ImportTermSet(memoryStream, synchroniseDeletions: synchronizeDeletions);
+                }
+
             }
         }
 
-        private static void ParseSubTerms(int lcid, TermStore termStore, bool overwriteExisting, ClientRuntimeContext clientContext, Term term, string[] items)
-        {
-            clientContext.Load(term, t => t.Id, t => t.Name, t => t.Terms);
-            clientContext.ExecuteQuery();
-            if (term.ServerObjectIsNull == false)
-            {
-                for (var q = 3; q < items.Count(); q++)
-                {
-                    var subTermItem = items[q];
-                    var termId = Guid.Empty;
-                    string termName;
-                    if (subTermItem.IndexOf(";#", StringComparison.Ordinal) > -1)
-                    {
-                        termName = subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[0];
-                        termId = new Guid(subTermItem.Split(new string[] {";#"}, StringSplitOptions.None)[1]);
-                    }
-                    else
-                    {
-                        termName = subTermItem;
-                    }
-                    Term subTerm = null;
-                    if (termId != Guid.Empty)
-                    {
-                        subTerm = term.Terms.GetById(termId);
-                    }
-                    else
-                    {
-                        subTerm = term.Terms.GetByName(NormalizeName(termName));
-                    }
-                    clientContext.Load(term);
-                    try
-                    {
-                        clientContext.ExecuteQuery();
-                    }
-                    catch
-                    {
-                    }
-                    if (subTerm.ServerObjectIsNull == null)
-                    {
-                        term = term.AddTermToTerm(lcid, termName, termId);
-                    }
-                    else if (overwriteExisting && subTerm.ServerObjectIsNull == false)
-                    {
-                        clientContext.Load(subTerm, t => t.Id, t => t.Name, t => t.Terms);
-                        clientContext.ExecuteQuery();
-
-                        if (subTerm.Name != termName)
-                        {
-                            subTerm.Name = termName;
-                            termStore.CommitAll();
-                            clientContext.ExecuteQuery();
-                        }
-                        term = subTerm;
-                    }
-                    else
-                    {
-                        term = subTerm;
-                    }
-                }
-            }
-        }
+      
 
         private static Term AddTermToTerm(this Term term, int lcid, string termLabel, Guid termId)
         {
@@ -1601,7 +1484,7 @@ namespace Microsoft.SharePoint.Client
             }
             catch (Exception)
             {
-                ///If there is an exception the hidden field might be present
+                // If there is an exception the hidden field might be present
                 FieldCollection _fields = web.Fields;
                 web.Context.Load(_fields, fc => fc.Include(f => f.Id, f => f.InternalName));
                 web.Context.ExecuteQuery();
@@ -1655,7 +1538,7 @@ namespace Microsoft.SharePoint.Client
             }
             catch (Exception)
             {
-                ///If there is an exception the hidden field might be present
+                // If there is an exception the hidden field might be present
                 FieldCollection _fields = list.Fields;
                 list.Context.Load(_fields, fc => fc.Include(f => f.Id, f => f.InternalName));
                 list.Context.ExecuteQuery();

--- a/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
@@ -20,7 +20,6 @@ You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) w
     public class GetWebTemplates : SPOAdminCmdlet
     {
         [Parameter(Mandatory = false)]
-        [Alias("LCID")]
         public uint Lcid;
 
         [Parameter(Mandatory = false)]

--- a/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
+++ b/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
@@ -24,7 +24,7 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
         public string Path;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
-        public int LCID = 1033;
+        public int Lcid = 1033;
 
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public string TermStoreName;
@@ -50,11 +50,11 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
             {
                 var taxSession = TaxonomySession.GetTaxonomySession(ClientContext);
                 var termStore = taxSession.TermStores.GetByName(TermStoreName);
-                ClientContext.Site.ImportTerms(lines, LCID, termStore, Delimiter, Force);
+                ClientContext.Site.ImportTerms(lines, Lcid, termStore, Delimiter, Force);
             }
             else
             {
-                ClientContext.Site.ImportTerms(lines, LCID, Delimiter, Force);
+                ClientContext.Site.ImportTerms(lines, Lcid, Delimiter, Force);
             }
         }
 

--- a/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
+++ b/Solutions/PowerShell.Commands/Commands/Taxonomy/ImportTaxonomy.cs
@@ -32,8 +32,8 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
         [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets)]
         public string Delimiter = "|";
 
-        [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets, HelpMessage = "If specified, existing terms will be overwritten. Notice that this only works if you include term ids in your import data.")]
-        public SwitchParameter Force;
+        [Parameter(Mandatory = false, ParameterSetName = ParameterAttribute.AllParameterSets, HelpMessage = "If specified, terms that exist in the termset, but are not in the imported data will be removed.")]
+        public SwitchParameter SynchronizeDeletions;
 
         protected override void ExecuteCmdlet()
         {
@@ -50,11 +50,11 @@ PS:> Import-SPOTaxonomy -Terms 'Company|Locations|Stockholm|Central','Company|Lo
             {
                 var taxSession = TaxonomySession.GetTaxonomySession(ClientContext);
                 var termStore = taxSession.TermStores.GetByName(TermStoreName);
-                ClientContext.Site.ImportTerms(lines, Lcid, termStore, Delimiter, Force);
+                ClientContext.Site.ImportTerms(lines, Lcid, termStore, Delimiter, SynchronizeDeletions);
             }
             else
             {
-                ClientContext.Site.ImportTerms(lines, Lcid, Delimiter, Force);
+                ClientContext.Site.ImportTerms(lines, Lcid, Delimiter, SynchronizeDeletions);
             }
         }
 


### PR DESCRIPTION
Refactored ImportTerms method that supports the TermGroup|TermSet|Term format to utilize the ImportTerms functionality that supports the 'classic' CSV format. Result is easier to maintain and only one import routine instead of 2.
Removed 'force' parameter from the Import-SPOTaxonomy cmdlet and introduced an SynchronizeDeletions parameter, in sync with the ImportTerms method.