### PR TITLE
Added parameters for activate/deactivate/online and functions to fully r...

### DIFF
--- a/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/BrandingHelper.cs
+++ b/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/BrandingHelper.cs
@@ -1,18 +1,16 @@
 ﻿using Microsoft.SharePoint.Client;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Text;
-using System.Xml.Linq;
 
 namespace Contoso.Branding.ApplyBranding
 {
     static class BrandingHelper
     {
+
+        #region "activate branding functions"
+
         public static void UploadFile(ClientContext clientContext, string name, string folder, string path)
         {
-
             var web = clientContext.Web;
             var filePath = web.ServerRelativeUrl.TrimEnd(Program.trimChars) + "/" + path + "/";
 
@@ -45,9 +43,14 @@ namespace Contoso.Branding.ApplyBranding
             SetMasterPageMetadata(web, uploadFile);
             CheckInPublishAndApproveFile(uploadFile);
 
+            //store the currently used master pages so we can switch back upon deactivation
+            var allWebProperties = web.AllProperties;
+            allWebProperties["OriginalMasterUrl"] = web.MasterUrl;
+            allWebProperties["CustomMasterUrl"] = web.CustomMasterUrl;
+
             var masterUrl = string.Concat(masterPath, folder, (string.IsNullOrEmpty(folder) ? string.Empty : "/"), name);
-            web.CustomMasterUrl = masterUrl;
             web.MasterUrl = masterUrl;
+            web.CustomMasterUrl = masterUrl;
             web.Update();
             clientContext.ExecuteQuery();
         }
@@ -122,7 +125,6 @@ namespace Contoso.Branding.ApplyBranding
                 Url = fileUrl,
                 Overwrite = true
             };
-
             var uploadFile = folder.Files.Add(spFile);
             web.Context.Load(uploadFile, f => f.CheckOutType, f => f.Level);
             web.Context.ExecuteQuery();
@@ -219,5 +221,86 @@ namespace Contoso.Branding.ApplyBranding
                 web.Context.ExecuteQuery();
             }
         }
+
+        #endregion
+
+        #region "deactivate branding functions"
+
+        public static void RemoveFile(ClientContext clientContext, string name, string folder, string path)
+        {
+            var web = clientContext.Web;
+            var filePath = web.ServerRelativeUrl.TrimEnd(Program.trimChars) + "/" + path + "/";
+            
+            Console.WriteLine("Removing file {0} from {1}{2}", name, filePath, folder);
+
+            DeleteFile(web, name, filePath, folder);
+        }
+
+        public static void RemoveFolder(ClientContext clientContext, string folder, string path)
+        {
+            var web = clientContext.Web;
+            var filePath = web.ServerRelativeUrl.TrimEnd(Program.trimChars) + "/" + path + "/";
+            var folderToDelete = web.GetFolderByServerRelativeUrl(string.Concat(filePath, folder));
+            Console.WriteLine("Removing folder {0} from {1}", folder, path);
+            folderToDelete.DeleteObject();
+            clientContext.ExecuteQuery();
+        }
+
+        public static void RemoveMasterPage(ClientContext clientContext, string name, string folder)
+        {
+            var web = clientContext.Web;
+            clientContext.Load(web, w => w.AllProperties);
+            clientContext.ExecuteQuery();
+
+            Console.WriteLine("Deactivating and removing {0} from {1}", name, web.ServerRelativeUrl);            
+            
+            //set master pages back to the defaults that were being used
+            if (web.AllProperties.FieldValues.ContainsKey("OriginalMasterUrl"))
+            {
+                web.MasterUrl = (string)web.AllProperties["OriginalMasterUrl"];
+            }
+            if (web.AllProperties.FieldValues.ContainsKey("CustomMasterUrl"))
+            {
+                web.CustomMasterUrl = (string)web.AllProperties["CustomMasterUrl"];
+            }
+            web.Update();
+            clientContext.ExecuteQuery();
+
+            //now that the master page is set back to its default, re-reference the web from context and delete the custom master pages
+            web = clientContext.Web;
+            var lists = web.Lists;
+            var gallery = web.GetCatalog(116);
+            clientContext.Load(lists, l => l.Include(ll => ll.DefaultViewUrl));
+            clientContext.Load(gallery, g => g.RootFolder.ServerRelativeUrl);
+            clientContext.ExecuteQuery();
+            var masterPath = gallery.RootFolder.ServerRelativeUrl.TrimEnd(new char[] { '/' }) + "/";
+            DeleteFile(web, name, masterPath, folder);
+        }
+
+        public static void RemovePageLayout(ClientContext clientContext, string name, string folder)
+        {
+            var web = clientContext.Web;
+            var lists = web.Lists;
+            var gallery = web.GetCatalog(116);
+            clientContext.Load(lists, l => l.Include(ll => ll.DefaultViewUrl));
+            clientContext.Load(gallery, g => g.RootFolder.ServerRelativeUrl);
+            clientContext.ExecuteQuery();
+
+            Console.WriteLine("Removing page layout {0} from {1}", name, clientContext.Web.ServerRelativeUrl);
+
+            var masterPath = gallery.RootFolder.ServerRelativeUrl.TrimEnd(Program.trimChars) + "/";
+            
+            DeleteFile(web, name, masterPath, folder);
+        }
+
+        private static void DeleteFile(Web web, string fileName, string serverPath, string serverFolder)
+        {
+            var fileUrl = string.Concat(serverPath, serverFolder, (string.IsNullOrEmpty(serverFolder) ? string.Empty : "/"), fileName);
+            var fileToDelete = web.GetFileByServerRelativeUrl(fileUrl);
+            fileToDelete.DeleteObject();
+            web.Context.ExecuteQuery();
+        }
+
+        #endregion
     }
 }

--- a/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/Program.cs
+++ b/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/Program.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.SharePoint.Client;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Security;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 
 namespace Contoso.Branding.ApplyBranding
@@ -15,31 +11,72 @@ namespace Contoso.Branding.ApplyBranding
 
         static void Main(string[] args)
         {
-            var branding = XDocument.Load("settings.xml").Element("branding");
-            var url = branding.Attribute("url").Value;
-            
-            var username = GetUserName();
-            var password = GetPassword();
-            var credentials = new SharePointOnlineCredentials(username, password);
+            var isOnline = false;
 
-            foreach (var site in branding.Element("sites").Descendants("site"))
+            //check to ensure there's at least one argument
+            if (args.Length < 1 || args.Length > 2)
             {
-                var siteUrl = url.TrimEnd(trimChars) + "/" + site.Attribute("url").Value.TrimEnd(trimChars);
-                using (ClientContext clientContext = new ClientContext(siteUrl))
+                DisplayUsage();
+                return;
+            }
+            else if (args.Length > 1)
+            {
+                //assuming online
+                if (args[1] == "online")
                 {
-                    clientContext.Credentials = credentials;
-                    clientContext.Load(clientContext.Web);
-                    clientContext.ExecuteQuery();
-
-                    UploadFiles(clientContext, branding);
-                    UploadMasterPages(clientContext, branding);
-                    UploadPageLayouts(clientContext, branding);       
+                    isOnline = true;
                 }
-            }            
+            }
             
-            Console.WriteLine("Done!");
-            Console.ReadLine();
+            //activate or deactivate the branding
+            if (args[0].ToLower() == "activate" || args[0].ToLower() == "deactivate")
+            {
+                var branding = XDocument.Load("settings.xml").Element("branding");
+                var url = branding.Attribute("url").Value;
+
+                foreach (var site in branding.Element("sites").Descendants("site"))
+                {
+                    var siteUrl = url.TrimEnd(trimChars) + "/" + site.Attribute("url").Value.TrimEnd(trimChars);
+                    using (ClientContext clientContext = new ClientContext(siteUrl))
+                    {
+                        if (isOnline)
+                        {
+                            //only relevant if SharePoint Online
+                            var username = GetUserName();
+                            var password = GetPassword();
+                            var credentials = new SharePointOnlineCredentials(username, password);
+                            clientContext.Credentials = credentials;
+                        }
+
+                        clientContext.Load(clientContext.Web);
+                        clientContext.ExecuteQuery();
+                        switch (args[0].ToLower())
+                        {
+                            case "activate":
+                                UploadFiles(clientContext, branding);
+                                UploadMasterPages(clientContext, branding);
+                                UploadPageLayouts(clientContext, branding);
+                                break;
+                            case "deactivate":
+                                RemoveFiles(clientContext, branding);
+                                RemoveMasterPages(clientContext, branding);
+                                RemovePageLayouts(clientContext, branding);
+                                break;
+                        }
+                    }
+                }
+                Console.WriteLine("Done!");
+                Console.ReadLine();
+            }                
+            //invalid parameter(s)
+            else
+            {
+                DisplayUsage();
+                return;
+            }
         }
+
+        #region "activate branding functions"
 
         private static void UploadFiles(ClientContext clientContext, XElement branding)
         {
@@ -76,6 +113,55 @@ namespace Contoso.Branding.ApplyBranding
                 BrandingHelper.UploadPageLayout(clientContext, name, folder, title, publishingAssociatedContentType);
             }
         }
+
+        #endregion
+
+        #region "deactivate branding functions"
+
+        private static void RemoveFiles(ClientContext clientContext, XElement branding)
+        {
+            var name = "";
+            var folder = "";
+            var path = "";            
+            foreach (var file in branding.Element("files").Descendants("file"))
+            {
+                name = file.Attribute("name").Value;
+                folder = file.Attribute("folder").Value.TrimEnd(trimChars);
+                path = file.Attribute("path").Value.TrimEnd(trimChars);
+
+                BrandingHelper.RemoveFile(clientContext, name, folder, path);
+            }
+            BrandingHelper.RemoveFolder(clientContext, folder, path);
+        }
+
+        private static void RemoveMasterPages(ClientContext clientContext, XElement branding)
+        {
+            var name = "";
+            var folder = "";
+            foreach (var masterpage in branding.Element("masterpages").Descendants("masterpage"))
+            {
+                name = masterpage.Attribute("name").Value;
+                folder = masterpage.Attribute("folder").Value.TrimEnd(new char[] { '/' });
+
+                BrandingHelper.RemoveMasterPage(clientContext, name, folder);
+            }
+            BrandingHelper.RemoveFolder(clientContext, folder, "_catalogs/masterpage");
+        }
+
+        private static void RemovePageLayouts(ClientContext clientContext, XElement branding)
+        {
+            foreach (var pagelayout in branding.Element("pagelayouts").Descendants("pagelayout"))
+            {
+                var name = pagelayout.Attribute("name").Value;
+                var folder = pagelayout.Attribute("folder").Value.TrimEnd(trimChars);
+                var publishingAssociatedContentType = pagelayout.Attribute("publishingAssociatedContentType").Value;
+                var title = pagelayout.Attribute("title").Value;
+
+                BrandingHelper.RemovePageLayout(clientContext, name, folder);
+            }
+        }
+
+        #endregion
 
         #region "helper functions"
 
@@ -132,6 +218,19 @@ namespace Contoso.Branding.ApplyBranding
             }
             return strUserName;
         }
+
+        static void DisplayUsage()
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("Please specify 'activate' or 'deactivate' and optionally 'online'");
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine("Example 1 (SharePoint Online): \n Contoso.Branding.ApplyBranding.Console.exe activate online");
+            Console.WriteLine("Example 2 (SharePoint Online):  \n Contoso.Branding.ApplyBranding.Console.exe deactivate online");
+            Console.WriteLine("Example 3 (SharePoint On-premises):  \n Contoso.Branding.ApplyBranding.Console.exe activate");
+            Console.WriteLine("Example 4 (SharePoint On-premises):  \n Contoso.Branding.ApplyBranding.Console.exe deactivate");
+            Console.ResetColor();
+        }
+        
         #endregion
     }
 }


### PR DESCRIPTION
Updated the Branding.ApplyBranding solution to support on-premises environments by parameterizing the console app. Assembly references for v 15/16 need to be changed accordingly as they're not dynamic. Once that's done, you can run this as shown in below examples. Activate commands fully deploy branding and deactivate commands fully retract the branding.

Example 1 (SharePoint Online): Contoso.Branding.ApplyBranding.Console.exe activate online
Example 2 (SharePoint Online): Contoso.Branding.ApplyBranding.Console.exe deactivate online
Example 3 (SharePoint On-premises): Contoso.Branding.ApplyBranding.Console.exe activate
Example 4 (SharePoint On-premises): Contoso.Branding.ApplyBranding.Console.exe deactivate

![brandng applybranding_activate_1_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989495/fe3ddad6-a946-11e4-8964-a42493a13b31.jpg)
![brandng applybranding_activate_2_files_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989491/fe3c1e30-a946-11e4-9afb-f588825d3520.jpg)
![brandng applybranding_activate_3_masterpagespagelayouts_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989493/fe3c4fcc-a946-11e4-8d7c-a07ee5ba4b93.jpg)
![brandng applybranding_deactivate_1_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989490/fe3a18d8-a946-11e4-8346-43f24d60a442.jpg)
![brandng applybranding_deactivate_2_files_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989492/fe3c3398-a946-11e4-92dc-de9e74492b4f.jpg)
![brandng applybranding_deactivate_3_masterpagespagelayouts_2015-01-31_12-37-49](https://cloud.githubusercontent.com/assets/1846656/5989494/fe3d6d80-a946-11e4-9f80-3d22b0371117.jpg)





