### PR TITLE
Rely on ?? operator at call site instead of passing default values to Get-methods

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
@@ -192,18 +192,28 @@ namespace Microsoft.SharePoint.Client.Tests
                 web.CreateList(ListTemplateType.GenericList, listName, false);
 
                 var list = web.GetListByTitle(listName);
+
                 var key = "key";
                 var value = "value";
-
                 list.SetPropertyBagValue(key, value);
                 var retrievedValue = list.GetPropertyBagValueString(key);
-
                 Assert.AreEqual(value, retrievedValue);
+
+                var key2 = "key2";
+                var value2 = 123;
+                list.SetPropertyBagValue(key2, value2);
+                var retrievedValue2 = list.GetPropertyBagValueInt(key2);
+                Assert.IsTrue(retrievedValue2.HasValue);
+                Assert.AreEqual(value2, retrievedValue2.Value);
+
+                var retrievedValue3 = list.GetPropertyBagValueInt("nonExisting");
+                Assert.IsFalse(retrievedValue3.HasValue);
 
                 list.DeleteObject();
                 clientContext.ExecuteQueryRetry();
             }
         }
+
         #endregion
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/AppModelExtensions/ListExtensionsTests.cs
@@ -181,5 +181,29 @@ namespace Microsoft.SharePoint.Client.Tests
         }
         #endregion
 
+        #region Property bag tests
+        [TestMethod()]
+        public void SetPropertyBagValueTest()
+        {
+            using (var clientContext = TestCommon.CreateClientContext())
+            {
+                var listName = "Test_list_" + DateTime.Now.ToFileTime();
+                var web = clientContext.Web;
+                web.CreateList(ListTemplateType.GenericList, listName, false);
+
+                var list = web.GetListByTitle(listName);
+                var key = "key";
+                var value = "value";
+
+                list.SetPropertyBagValue(key, value);
+                var retrievedValue = list.GetPropertyBagValueString(key);
+
+                Assert.AreEqual(value, retrievedValue);
+
+                list.DeleteObject();
+                clientContext.ExecuteQueryRetry();
+            }
+        }
+        #endregion
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -197,13 +197,12 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Get string typed property bag value. If does not contain, returns given default value.
+        /// Get string typed property bag value.
         /// </summary>
         /// <param name="list">List to read the property bag value from</param>
         /// <param name="key">Key of the property bag entry to return</param>
-        /// <param name="defaultValue"></param>
         /// <returns>Value of the property bag entry as string</returns>
-        public static string GetPropertyBagValueString(this List list, string key, string defaultValue)
+        public static string GetPropertyBagValueString(this List list, string key)
         {
             object value = GetPropertyBagValueInternal(list, key);
             if (value != null)

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/ListExtensions.cs
@@ -177,13 +177,12 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Get int typed property bag value. If does not contain, returns default value.
+        /// Get int typed property bag value
         /// </summary>
         /// <param name="list">List to read the property bag value from</param>
         /// <param name="key">Key of the property bag entry to return</param>
-        /// <param name="defaultValue"></param>
         /// <returns>Value of the property bag entry as integer</returns>
-        public static int? GetPropertyBagValueInt(this List list, string key, int defaultValue)
+        public static int? GetPropertyBagValueInt(this List list, string key)
         {
             object value = GetPropertyBagValueInternal(list, key);
             if (value != null)
@@ -192,7 +191,7 @@ namespace Microsoft.SharePoint.Client
             }
             else
             {
-                return defaultValue;
+                return null;
             }
         }
 

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/RecordsManagementExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/RecordsManagementExtensions.cs
@@ -259,7 +259,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns>True if in place records management settings are active for this list</returns>
         public static bool IsListRecordSettingDefined(this List list)
         {
-            string useListSpecific = list.GetPropertyBagValueString(ECM_IPR_LIST_USE_LIST_SPECIFIC, "");
+            string useListSpecific = list.GetPropertyBagValueString(ECM_IPR_LIST_USE_LIST_SPECIFIC);
 
             if (!String.IsNullOrEmpty(useListSpecific))
             {
@@ -323,7 +323,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns><see cref="EcmListManualRecordDeclaration"/> enum that defines the manual in place record declaration settings for this list</returns>
         public static EcmListManualRecordDeclaration GetListManualRecordDeclaration(this List list)
         {
-            string useListSpecific = list.GetPropertyBagValueString(ECM_IPR_LIST_USE_LIST_SPECIFIC, "");
+            string useListSpecific = list.GetPropertyBagValueString(ECM_IPR_LIST_USE_LIST_SPECIFIC);
 
             if (!String.IsNullOrEmpty(useListSpecific))
             {
@@ -336,7 +336,7 @@ namespace Microsoft.SharePoint.Client
                    }
                    else
                    {
-                       string manualDeclararion = list.GetPropertyBagValueString(ECM_ALLOW_MANUAL_DECLARATION, "");
+                       string manualDeclararion = list.GetPropertyBagValueString(ECM_ALLOW_MANUAL_DECLARATION);
                        bool manual = false;
                        if (Boolean.TryParse(manualDeclararion, out manual))
                        {
@@ -452,7 +452,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns>True if auto record declaration is active, false otherwise</returns>
         public static bool GetListAutoRecordDeclaration(this List list)
         {
-            string autoDeclare = list.GetPropertyBagValueString(ECM_AUTO_DECLARE_RECORDS, "");
+            string autoDeclare = list.GetPropertyBagValueString(ECM_AUTO_DECLARE_RECORDS);
 
             if (!String.IsNullOrEmpty(autoDeclare))
             {


### PR DESCRIPTION
Removed the default argument to ListExtensions.GetPropertyBagValueString and ListExtensions.GetPropertyBagValueInt.

The default argument to GetPropertyBagValueString was never implemented and OfficeDevPnP.Core code calling GetPropertyBagValueString didn't rely on the default value behavior being implemented.

Instead of passing default values to GetPropertyBagValueString and GetPropertyBagValueString, why not use the build-in C# ?? operator at the call site?

For instance:

            int? x = 0;
            int? y = null;

            System.Console.WriteLine(x.HasValue); // true
            System.Console.WriteLine(y.HasValue); // false
            System.Console.WriteLine(y ?? 123);   // 123

            string z = null;
            System.Console.WriteLine(z ?? "foo"); // foo