### PR TITLE
Replaced confirmation message to reflect actual event. 

### DIFF
--- a/Scenarios/Provisioning.SiteModifier/Provisioning.SiteModifierWeb/Pages/Default.aspx
+++ b/Scenarios/Provisioning.SiteModifier/Provisioning.SiteModifierWeb/Pages/Default.aspx
@@ -4,7 +4,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head runat="server">
-    <title>Site Modifyer</title>
+    <title>Site Modifier</title>
     <script type="text/javascript" src="../Scripts/jquery-1.9.1.js"></script>
     <script type="text/javascript" src="../Scripts/app.js"></script>
 </head>
@@ -28,6 +28,7 @@
         <br />
         <asp:Button runat="server" ID="btnSubmit" Text="Apply changes" OnClick="btnSubmit_Click"/>
         <asp:Button runat="server" ID="btnRemove" Text="Remove changes" OnClick="btnRemove_Click" />  
+        <br /><br />
          <asp:Label ID="lblStatus" runat="server" />
         <br />
     </div>

--- a/Scenarios/Provisioning.SiteModifier/Provisioning.SiteModifierWeb/Pages/Default.aspx.cs
+++ b/Scenarios/Provisioning.SiteModifier/Provisioning.SiteModifierWeb/Pages/Default.aspx.cs
@@ -114,7 +114,7 @@ namespace Provisioning.SiteModifierWeb
             using (var ctx = spContext.CreateUserClientContextForSPHost())
             {
                 DeleteJsLink(ctx);
-                lblStatus.Text = string.Format("Modify Site link has been added to the Site Actions meny of <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
+                lblStatus.Text = string.Format("Modify Site link has been removed from the Site Actions menu of <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
             }
         }
 


### PR DESCRIPTION
Slight spelling corrections and performed testing on the solution.