### PR TITLE
Resolve #468 Components/Taxonomypicker - Empty UL was not inserted for childnodes.

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -1030,7 +1030,11 @@
                 });
             }
             else {
-                tHtml += '</li>'
+                //TODO We should not add these nodes here. Adds to much overhead on large termsets.
+                //These could be created at inserttime as I don't see any case where
+                //we have several parents in the containing div. It should be as the commented line below
+                //tHtml += '</li>'
+                tHtml += '<ul class="cam-taxpicker-treenode-ul"></ul></li>';
             }
 
             outHtml += tHtml;


### PR DESCRIPTION
Adding a new node requires that the containing div has a sibling UL that
is empty where the new node can be added. This UL was not constructed for
childnodes.

This resolves #468