### PR TITLE
Added method to Publish a Custom Event in the WorkflowExtensions type.

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/WorkflowExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/WorkflowExtensions.cs
@@ -293,5 +293,24 @@ namespace Microsoft.SharePoint.Client
             clientContext.ExecuteQueryRetry();
         }
         #endregion
+
+        #region Messaging
+
+        /// <summary>
+        /// Publish a custom event to a target workflow instance
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="eventName">The name of the target event</param>
+        /// <param name="payload">The payload that will be sent to the event</param>
+        public static void PublishCustomEvent(this WorkflowInstance instance, String eventName, String payload)
+        {
+            var clientContext = instance.Context as ClientContext;
+            var servicesManager = new WorkflowServicesManager(clientContext, clientContext.Web);
+            var workflowInstanceService = servicesManager.GetWorkflowInstanceService();
+            workflowInstanceService.PublishCustomEvent(instance, eventName, payload);
+            clientContext.ExecuteQueryRetry();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
I've added an extension method to support publishing custom events to workflow instances. However, as far as I can see, we miss a test plan for the WorkflowExtensions type. I would like to think about a suitable way to create a test plan for the WorkflowExtensions type, as like as we have for most of the other extension types. Nevertheless, it is not an easy task, because it involves having workflow definitions and workflow instances to play with. What's your feeling? Is It Worth the time, to find a way to test the WorkflowExtensions type? Thanks.

Of course, if you think that this method is useless ... just skip it :).