### PR TITLE
Taxonomypicker

### DIFF
--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -107,7 +107,13 @@
                         this.FilteredFlatTerms.push(this.FlatTerms[i]);
                         var term = this.FlatTerms[i];
                         var path = term.PathOfTerm.split(';');
+
+                        // used when "filterTermId" option is provided
                         if ((path.length == this.LevelToShowTerms && this.FilterTermId != null && this.FilterTermId == term.Id) || (this.FilterTermId != null && filterTerm && term.PathOfTerm.indexOf(filterTerm.Name) > -1 && this.LevelToShowTerms - 1 == term.Level)) {
+                            this.FlatTermsForSuggestion.push(term);
+                        }
+                        // if no "filterTermId" option is provided add the terms accordingly to the suggestions list
+                        else if (!this.FilterTermId && path.length <= this.LevelToShowTerms) {
                             this.FlatTermsForSuggestion.push(term);
                         }
                     }

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -47,7 +47,7 @@
         this.IsOpenForTermCreation = false; //bool indicating if the termset is open for new term creation
         this.NewTerm = null; //the new term being added
         this.FilterTermId = options.filterTermId; // To support filter terms based on Id
-        this.LevelToShowTerms = options.levelToShowTerms; // show terms only till the specified level
+        this.LevelToShowTerms = options.levelToShowTerms || 7; // show terms only till the specified level
         this.UseTermSetasRootNode = options.useTermSetasRootNode //bool indicating if termset to be shown as root node or not
     }
     $.extend(TermSet.prototype, {

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -846,7 +846,15 @@
         //used to check if focus is lost from the control (invalidate and hide suggestions)
         checkExternalClick: function (event) {
             //check if the target is outside the picker
-            if (!$.contains(this._control[0], event.target) && !$.contains(this._suggestionContainer[0], event.target) && this._dialog != null && !$.contains(this._dialog[0], event.target)) {
+            if (!$.contains(this._control[0], event.target) && !$.contains(this._suggestionContainer[0], event.target) && this._dialog == null) {
+                var rawText = this._editor.text(); //the raw text in the editor (html stripped out)
+                if (rawText) {
+                    var textValidation = this.validateText(rawText); //get the text validation
+                    var html = this.markInvalidTerms(textValidation); //mark invalid terms
+                    this._editor.html(html); //set the editor
+                    this._suggestionContainer.hide(); //hide suggestions
+                }
+            } else if (!$.contains(this._control[0], event.target) && !$.contains(this._suggestionContainer[0], event.target) && this._dialog != null && !$.contains(this._dialog[0], event.target)) {
                 var rawText = this._editor.text(); //the raw text in the editor (html stripped out)
                 var textValidation = this.validateText(rawText); //get the text validation
                 var html = this.markInvalidTerms(textValidation); //mark invalid terms

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -107,7 +107,7 @@
                         this.FilteredFlatTerms.push(this.FlatTerms[i]);
                         var term = this.FlatTerms[i];
                         var path = term.PathOfTerm.split(';');
-                        if ((path.length == this.LevelToShowTerms && this.FilterTermId != null && this.FilterTermId == term.Id) || (this.FilterTermId != null && term.PathOfTerm.indexOf(filterTerm.Name) > -1 && this.LevelToShowTerms - 1 == term.Level)) {
+                        if ((path.length == this.LevelToShowTerms && this.FilterTermId != null && this.FilterTermId == term.Id) || (this.FilterTermId != null && filterTerm && term.PathOfTerm.indexOf(filterTerm.Name) > -1 && this.LevelToShowTerms - 1 == term.Level)) {
                             this.FlatTermsForSuggestion.push(term);
                         }
                     }

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
@@ -198,7 +198,7 @@
 
 .root.cam-taxpicker-treenode-ul {
     display: block;
-    margin-left: 0px;
+    margin-left: 15px;
 }
 
 .cam-taxpicker-treenode-li {

--- a/Samples/Core.TaxonomyPicker/readme.md
+++ b/Samples/Core.TaxonomyPicker/readme.md
@@ -100,13 +100,17 @@ Any hidden input element can be converted to a Taxonomy Picker.  This includes r
 **Client-side example:**
 
 ```HTML
-	<input type="hidden" id="taxPickerContinent" />
+	<div class="ms-core-form-line" style="margin-bottom: 0px;">
+	     <input type="hidden" id="taxPickerContinent" />
+	</div>
 ```
 
 **Server-side example:**
 
 ```ASPX
-	<asp:HiddenField runat="server" ID="taxPickerContinent" />
+	<div class="ms-core-form-line" style="margin-bottom: 0px;">
+		<asp:HiddenField runat="server" ID="taxPickerContinent" />
+	</div>
 ```
 
 ## Transforming the HTML into a Taxonomy Picker Control ##


### PR DESCRIPTION
Fixed several things in the taxonomypicker as follow:
- documentation <div> wrapper is required by the logic
- indenting of the terms wasn't working because of wrong value in css
- Suggestions list wasn't populated when no filterTermId was added
- External click not fired when this._dialog == null