### PR TITLE
Option to get all available content types for the current web/fixed issue with create content type in the current web with a parent defined higher in the site hierarchy

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -1123,7 +1123,7 @@ namespace Microsoft.SharePoint.Client
             Log.Info(Constants.LOGGING_SOURCE, CoreResources.FieldAndContentTypeExtensions_CreateContentType01, name, id);
 
             // Load the current collection of content types
-            ContentTypeCollection contentTypes = web.ContentTypes;
+            ContentTypeCollection contentTypes = web.AvailableContentTypes;
             web.Context.Load(contentTypes);
             web.Context.ExecuteQueryRetry();
             ContentTypeCreationInformation newCt = new ContentTypeCreationInformation();

--- a/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
+++ b/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
@@ -14,6 +14,8 @@ namespace OfficeDevPnP.PowerShell.Commands
     {
         [Parameter(Mandatory = false, Position=0, ValueFromPipeline=true, HelpMessage="Name or ID of the content type to retrieve")]
         public ContentTypePipeBind Identity;
+        [Parameter(Mandatory = false, Position = 1, ValueFromPipeline = false, HelpMessage = "Search site hierarchy for content types")]
+        public SwitchParameter InSiteHierarchy;
 
         protected override void ExecuteCmdlet()
         {
@@ -23,11 +25,11 @@ namespace OfficeDevPnP.PowerShell.Commands
                 ContentType ct;
                 if (!string.IsNullOrEmpty(Identity.Id))
                 {
-                    ct = SelectedWeb.GetContentTypeById(Identity.Id);
+                    ct = (InSiteHierarchy.IsPresent) ? SelectedWeb.GetContentTypeById(Identity.Id, true) : SelectedWeb.GetContentTypeById(Identity.Id);
                 }
                 else
                 {
-                    ct = SelectedWeb.GetContentTypeByName(Identity.Name);
+                    ct = (InSiteHierarchy.IsPresent) ? SelectedWeb.GetContentTypeByName(Identity.Name, true) : SelectedWeb.GetContentTypeByName(Identity.Name);
                 }
                 if (ct != null)
                 {
@@ -37,7 +39,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             }
             else
             {
-                var cts = ClientContext.LoadQuery(SelectedWeb.ContentTypes);
+                var cts = (InSiteHierarchy.IsPresent) ? ClientContext.LoadQuery(SelectedWeb.AvailableContentTypes) : ClientContext.LoadQuery(SelectedWeb.ContentTypes);
                 ClientContext.ExecuteQueryRetry();
     
                 WriteObject(cts, true);

--- a/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
+++ b/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
@@ -9,7 +9,7 @@ namespace OfficeDevPnP.PowerShell.Commands
     [CmdletHelp("Retrieves a content type")]
     [CmdletExample(
      Code = @"PS:> Get-SPOContentType -Identity ""Project Document""",
-     Remarks = @"This will add an existing content type to a list and sets it as the default content type", SortOrder = 1)]
+     Remarks = @"This will get a listing of content types within the current context", SortOrder = 1)]
     public class GetContentType : SPOWebCmdlet
     {
         [Parameter(Mandatory = false, Position=0, ValueFromPipeline=true, HelpMessage="Name or ID of the content type to retrieve")]

--- a/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
+++ b/Solutions/PowerShell.Commands/Commands/ContentTypes/GetContentType.cs
@@ -25,11 +25,11 @@ namespace OfficeDevPnP.PowerShell.Commands
                 ContentType ct;
                 if (!string.IsNullOrEmpty(Identity.Id))
                 {
-                    ct = (InSiteHierarchy.IsPresent) ? SelectedWeb.GetContentTypeById(Identity.Id, true) : SelectedWeb.GetContentTypeById(Identity.Id);
+                    ct = SelectedWeb.GetContentTypeById(Identity.Id, InSiteHierarchy.IsPresent);
                 }
                 else
                 {
-                    ct = (InSiteHierarchy.IsPresent) ? SelectedWeb.GetContentTypeByName(Identity.Name, true) : SelectedWeb.GetContentTypeByName(Identity.Name);
+                    ct = SelectedWeb.GetContentTypeByName(Identity.Name, InSiteHierarchy.IsPresent);
                 }
                 if (ct != null)
                 {


### PR DESCRIPTION
Allows user to optionally return all content types available to the current web.