### PR TITLE
Fix GetSiteCollection #521

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TenantExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TenantExtensions.cs
@@ -531,7 +531,8 @@ namespace Microsoft.SharePoint.Client
         /// <returns>An IList of SiteEntity objects</returns>
         public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex)
         {
-            return GetSiteCollections(tenant, startIndex, true);
+            //O365 Tenant Site Collection limit is 10000, and the GetSiteProperties returns 300.
+            return GetSiteCollections(tenant, startIndex, true, 10000);
         }
 
         /// <summary>
@@ -539,11 +540,12 @@ namespace Microsoft.SharePoint.Client
         /// </summary>
         /// <param name="tenant"></param>
         /// <returns>An IList of SiteEntity objects</returns>
-        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex, bool includeDetail)
+        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex, bool includeDetail, int endIndex)
         {
             var sites = new List<SiteEntity>();
 
-            for (int i = startIndex; i < 10000; i += 300)
+            //O365 Tenant Site Collection limit is 10000, and the GetSiteProperties returns 300.
+            for (int i = startIndex; i < endIndex; i += 300)
             {
                 var props = tenant.GetSiteProperties(i, includeDetail);
                 tenant.Context.Load(props);

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TenantExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/TenantExtensions.cs
@@ -515,32 +515,11 @@ namespace Microsoft.SharePoint.Client
 
         #region Site enumeration
         /// <summary>
-        /// Returns all site collections in the current Tenant. Use this with care for large tenants.
+        /// Returns all site collections in the current Tenant based on a startIndex. IncludeDetail adds additional properties to the SPSite object. EndIndex is the maximum number based on chunkcs of 300.
         /// </summary>
         /// <param name="tenant"></param>
         /// <returns>An IList of SiteEntity objects</returns>
-        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant)
-        {
-            return GetSiteCollections(tenant, 0);
-        }
-
-        /// <summary>
-        /// Returns all site collections in the current Tenant based on a startIndex.
-        /// </summary>
-        /// <param name="tenant"></param>
-        /// <returns>An IList of SiteEntity objects</returns>
-        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex)
-        {
-            //O365 Tenant Site Collection limit is 10000, and the GetSiteProperties returns 300.
-            return GetSiteCollections(tenant, startIndex, true, 10000);
-        }
-
-        /// <summary>
-        /// Returns all site collections in the current Tenant based on a startIndex. IncludeDetail
-        /// </summary>
-        /// <param name="tenant"></param>
-        /// <returns>An IList of SiteEntity objects</returns>
-        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex, bool includeDetail, int endIndex)
+        public static IList<SiteEntity> GetSiteCollections(this Tenant tenant, int startIndex = 0, bool includeDetail = true, int endIndex = 10000)
         {
             var sites = new List<SiteEntity>();
 


### PR DESCRIPTION
Can someone please review for quality as this modifies the Core project :) 

Enhanced GetSiteCollections to honor the 300 item limit by the GetSiteProperties method.
Carefully added method overrides to not break signatures of existing solutions
The method now has 3 overrides where you can provide a startIndex and includeDetail to fetch other SPSite properties.
The API does not provide a Take() equivilent though...