### PR TITLE
Added support for selecting sugestions using the keyboard, and some smal...

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -441,13 +441,6 @@
                     sel.click();
                     return false;
                 }
-                var newText = '';
-
-                //calculate new text and then convert to html
-                if (caret < rawText.length)
-                    newText = rawText.substring(0, caret - selection.length) + String.fromCharCode(keynum) + this.MarkerMarkup + rawText.substring(caret, rawText.length);
-                else
-                    newText = rawText.substring(0, caret - selection.length) + rawText.substring(caret, rawText.length) + String.fromCharCode(keynum) + this.MarkerMarkup;
 
                 //validate raw text OR mark invalid
                 var textValidation = this.validateText(rawText);

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Styles/taxonomypickercontrol.css
@@ -187,6 +187,7 @@
     cursor: pointer;
 }
 
+.cam-taxpicker-suggestion-item.selected,
 .cam-taxpicker-suggestion-item:hover {
     background-color: rgb(253, 238, 219);
 }


### PR DESCRIPTION
...ler updates. Smaller updates: Added support for enter key. Getting the marker more reliably, as doing a backspace, after a new keyword was added, resulted only in removing the ; you only were able to remove further text after clicking in the taxonomy field. Only allowing for one new taxonomy value to be added at once. Keywords only allow one level, when adding a second level keyword, it disappears when entered, now you can't add a second level keyword, and will instead add one to the root. Adding a new taxonomy value and then adding one in the next level on the new taxonomy node made possible by adding missing ul. The dlgCurrTermNode should be the newly created title node.