### PR TITLE
Updated token parser to be case insensitive and added caching

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/TokenParserTests.cs
@@ -28,17 +28,25 @@ namespace OfficeDevPnP.Core.Tests.Framework.ObjectHandlers
                 ctx.Load(themesCatalog, t => t.RootFolder.ServerRelativeUrl);
 
 
-                TokenParser parser = new TokenParser(ctx.Web);
+                var parser = new TokenParser(ctx.Web);
 
-                var site = parser.Parse("~site/test");
-                var sitecol = parser.Parse("~sitecollection/test");
-                var masterUrl = parser.Parse("~masterpagecatalog/test");
-                var themeUrl = parser.Parse("~themecatalog/test");
+                var site1 = parser.Parse("~siTE/test");
+                var site2 = parser.Parse("{site}/test");
+                var sitecol1 = parser.Parse("~siteCOLLECTION/test");
+                var sitecol2 = parser.Parse("{sitecollection}/test");
+                var masterUrl1 = parser.Parse("~masterpagecatalog/test");
+                var masterUrl2 = parser.Parse("{masterpagecatalog}/test");
+                var themeUrl1 = parser.Parse("~themecatalog/test");
+                var themeUrl2 = parser.Parse("{themecatalog}/test");
 
-                Assert.IsTrue(site == string.Format("{0}/test",ctx.Web.ServerRelativeUrl));
-                Assert.IsTrue(sitecol == string.Format("{0}/test", ctx.Site.ServerRelativeUrl));
-                Assert.IsTrue(masterUrl == string.Format("{0}/test", masterCatalog.RootFolder.ServerRelativeUrl));
-                Assert.IsTrue(themeUrl == string.Format("{0}/test", themesCatalog.RootFolder.ServerRelativeUrl));
+                Assert.IsTrue(site1 == string.Format("{0}/test", ctx.Web.ServerRelativeUrl));
+                Assert.IsTrue(site2 == string.Format("{0}/test", ctx.Web.ServerRelativeUrl));
+                Assert.IsTrue(sitecol1 == string.Format("{0}/test", ctx.Site.ServerRelativeUrl));
+                Assert.IsTrue(sitecol2 == string.Format("{0}/test", ctx.Site.ServerRelativeUrl));
+                Assert.IsTrue(masterUrl1 == string.Format("{0}/test", masterCatalog.RootFolder.ServerRelativeUrl));
+                Assert.IsTrue(masterUrl2 == string.Format("{0}/test", masterCatalog.RootFolder.ServerRelativeUrl));
+                Assert.IsTrue(themeUrl1 == string.Format("{0}/test", themesCatalog.RootFolder.ServerRelativeUrl));
+                Assert.IsTrue(themeUrl2 == string.Format("{0}/test", themesCatalog.RootFolder.ServerRelativeUrl));
             }
         }
     }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/MasterPageCatalogToken.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/MasterPageCatalogToken.cs
@@ -5,16 +5,20 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
     public class MasterPageCatalogToken : TokenDefinition
     {
         public MasterPageCatalogToken(Web web)
-            : base(web, "~masterpagecatalog")
+            : base(web, "~masterpagecatalog","{masterpagecatalog}")
         {
         }
 
         public override string GetReplaceValue()
         {
-            var catalog = Web.GetCatalog((int)ListTemplateType.MasterPageCatalog);
-            Web.Context.Load(catalog, c => c.RootFolder.ServerRelativeUrl);
-            Web.Context.ExecuteQueryRetry();
-            return catalog.RootFolder.ServerRelativeUrl;
+            if (this.CacheValue == null)
+            {
+                var catalog = Web.GetCatalog((int) ListTemplateType.MasterPageCatalog);
+                Web.Context.Load(catalog, c => c.RootFolder.ServerRelativeUrl);
+                Web.Context.ExecuteQueryRetry();
+                CacheValue = catalog.RootFolder.ServerRelativeUrl;
+            }
+            return CacheValue;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteCollectionToken.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteCollectionToken.cs
@@ -5,17 +5,21 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
     public class SiteCollectionToken : TokenDefinition
     {
         public SiteCollectionToken(Web web)
-            : base(web, "~sitecollection")
+            : base(web, "~sitecollection", "{sitecollection}")
         {
         }
 
         public override string GetReplaceValue()
         {
-            var context = this.Web.Context as ClientContext;
-            var site = context.Site;
-            context.Load(site, s => s.RootWeb.ServerRelativeUrl);
-            context.ExecuteQueryRetry();
-            return site.RootWeb.ServerRelativeUrl;
+            if (CacheValue == null)
+            {
+                var context = this.Web.Context as ClientContext;
+                var site = context.Site;
+                context.Load(site, s => s.RootWeb.ServerRelativeUrl);
+                context.ExecuteQueryRetry();
+                CacheValue = site.RootWeb.ServerRelativeUrl;
+            }
+            return CacheValue;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteToken.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/SiteToken.cs
@@ -5,15 +5,19 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
     public class SiteToken : TokenDefinition
     {
         public SiteToken(Web web)
-            : base(web, "~site")
+            : base(web, "~site", "{site}")
         {
         }
 
         public override string GetReplaceValue()
         {
-            Web.Context.Load(Web, w => w.ServerRelativeUrl);
-            Web.Context.ExecuteQueryRetry();
-            return Web.ServerRelativeUrl;
+            if (CacheValue == null)
+            {
+                Web.Context.Load(Web, w => w.ServerRelativeUrl);
+                Web.Context.ExecuteQueryRetry();
+                CacheValue = Web.ServerRelativeUrl;
+            }
+            return CacheValue;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/ThemeCatalogToken.cs
@@ -5,16 +5,20 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
     public class ThemeCatalogToken : TokenDefinition
     {
         public ThemeCatalogToken(Web web)
-            : base(web, "~themecatalog")
+            : base(web, "~themecatalog","{themecatalog}")
         {
         }
 
         public override string GetReplaceValue()
         {
-            var catalog = Web.GetCatalog((int)ListTemplateType.ThemeCatalog);
-            Web.Context.Load(catalog, c => c.RootFolder.ServerRelativeUrl);
-            Web.Context.ExecuteQueryRetry();
-            return catalog.RootFolder.ServerRelativeUrl;
+            if (CacheValue == null)
+            {
+                var catalog = Web.GetCatalog((int) ListTemplateType.ThemeCatalog);
+                Web.Context.Load(catalog, c => c.RootFolder.ServerRelativeUrl);
+                Web.Context.ExecuteQueryRetry();
+                CacheValue = catalog.RootFolder.ServerRelativeUrl;
+            }
+            return CacheValue;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TokenDefinition.cs
@@ -5,19 +5,28 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers
 {
     public abstract class TokenDefinition
     {
+        protected string CacheValue;
 
-        protected TokenDefinition(Web web, string token)
+        protected TokenDefinition(Web web, params string[] token)
         {
             this.Token = token;
             this.Web = web;
         }
         
-        public string Token { get; private set; }
+        public string[] Token { get; private set; }
         public Web Web { get; private set; }
 
-        public Regex Regex
+        public Regex[] Regex
         {
-            get { return new Regex(Token); }
+            get
+            {
+                var regexs = new Regex[this.Token.Length];
+                for (var q = 0; q < this.Token.Length;q++)
+                {
+                    regexs[q] = new Regex(this.Token[q], RegexOptions.IgnoreCase);
+                }
+                return regexs;
+            }
         }
 
         public abstract string GetReplaceValue();

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Remoting.Channels;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions;
 
@@ -27,9 +28,12 @@ namespace OfficeDevPnP.Core.Framework.ObjectHandlers
         {
             foreach (var token in _tokens)
             {
-                if (token.Regex.IsMatch(input))
+                foreach (var regex in token.Regex)
                 {
-                    input = token.Regex.Replace(input, token.GetReplaceValue());
+                    if (regex.IsMatch(input))
+                    {
+                        input = regex.Replace(input, token.GetReplaceValue());
+                    }
                 }
             }
 


### PR DESCRIPTION
Tokens now cache the replacement value
Tokens are now case insensitive
Added support for multiple token types, e.g. ~sitecollection and {sitecollection} will return the same value