### PR TITLE
Added support for adding webparts to webpart pages

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectPagesTests.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectPagesTests.cs
@@ -81,7 +81,8 @@ alert(""Hello!"");
             page.Overwrite = true;
             page.Url = "~site/sitepages/pagetest.aspx";
 
-            WebPart webPart = new WebPart();
+           
+            var webPart = new WebPart();
             webPart.Column = 1;
             webPart.Row = 1;
             webPart.Contents = webpartcontents;

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Page.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Model/Page.cs
@@ -12,7 +12,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
         #region Properties
         public string Url { get; set; }
 
-        public WikiPageLayout Layout { get; set; }
+        public WikiPageLayout? Layout { get; set; }
 
         public bool Overwrite { get; set; }
 
@@ -33,6 +33,16 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
             this.Overwrite = overwrite;
             this.Layout = layout;
 
+            if (webParts != null)
+            {
+                this.WebParts.AddRange(webParts);
+            }
+        }
+
+        public Page(string url, IEnumerable<WebPart> webParts)
+        {
+            this.Url = url;
+        
             if (webParts != null)
             {
                 this.WebParts.AddRange(webParts);

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Model/WebPart.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Model/WebPart.cs
@@ -5,14 +5,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Model
     public class WebPart : IEquatable<WebPart>
     {
         #region Properties
-        public uint Row { get; set; }
+        public uint? Row { get; set; }
 
-        public uint Column { get; set; }
+        public uint? Column { get; set; }
 
         public string Title { get; set; }
 
         public string Contents { get; set; }
 
+        public string Zone { get; set; }
+
+        public uint? Index { get; set; }
         #endregion
 
         #region Comparison code

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-04.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-04.cs
@@ -454,7 +454,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
         
         private int rowField;
         
+        private bool rowFieldSpecified;
+        
         private int columnField;
+        
+        private bool columnFieldSpecified;
+        
+        private string zoneField;
+        
+        private int indexField;
+        
+        private bool indexFieldSpecified;
         
         /// <remarks/>
         public string Contents {
@@ -489,6 +499,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
         }
         
         /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool RowSpecified {
+            get {
+                return this.rowFieldSpecified;
+            }
+            set {
+                this.rowFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
         public int Column {
             get {
@@ -496,6 +517,50 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
             }
             set {
                 this.columnField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool ColumnSpecified {
+            get {
+                return this.columnFieldSpecified;
+            }
+            set {
+                this.columnFieldSpecified = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public string Zone {
+            get {
+                return this.zoneField;
+            }
+            set {
+                this.zoneField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlAttributeAttribute()]
+        public int Index {
+            get {
+                return this.indexField;
+            }
+            set {
+                this.indexField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool IndexSpecified {
+            get {
+                return this.indexFieldSpecified;
+            }
+            set {
+                this.indexFieldSpecified = value;
             }
         }
     }
@@ -514,9 +579,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
         
         private bool overwriteField;
         
-        private bool overwriteFieldSpecified;
-        
         private WIKIPAGELAYOUT layoutField;
+        
+        private bool layoutFieldSpecified;
+        
+        public Page() {
+            this.overwriteField = false;
+        }
         
         /// <remarks/>
         [System.Xml.Serialization.XmlArrayItemAttribute(IsNullable=false)]
@@ -542,23 +611,13 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
         
         /// <remarks/>
         [System.Xml.Serialization.XmlAttributeAttribute()]
+        [System.ComponentModel.DefaultValueAttribute(false)]
         public bool Overwrite {
             get {
                 return this.overwriteField;
             }
             set {
                 this.overwriteField = value;
-            }
-        }
-        
-        /// <remarks/>
-        [System.Xml.Serialization.XmlIgnoreAttribute()]
-        public bool OverwriteSpecified {
-            get {
-                return this.overwriteFieldSpecified;
-            }
-            set {
-                this.overwriteFieldSpecified = value;
             }
         }
         
@@ -570,6 +629,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml.V201504 {
             }
             set {
                 this.layoutField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public bool LayoutSpecified {
+            get {
+                return this.layoutFieldSpecified;
+            }
+            set {
+                this.layoutFieldSpecified = value;
             }
         }
     }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-04.xsd
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/ProvisioningSchema-2015-04.xsd
@@ -662,7 +662,6 @@
   <xsd:complexType name="WebPart">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-        '
         Defines a webpart to be added to a wikipage
       </xsd:documentation>
     </xsd:annotation>
@@ -683,22 +682,34 @@
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-    <xsd:attribute name="Row" type="xsd:int" use="required">
+    <xsd:attribute name="Row" type="xsd:int" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          Required: Defines the row to add the webpart to
+          Optional: Defines the row to add the webpart to
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-
-    <xsd:attribute name="Column" type="xsd:int" use="required">
+    <xsd:attribute name="Column" type="xsd:int" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          Required: Defines the column to add the webpart to
+          Optional: Defines the column to add the webpart to
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-
+    <xsd:attribute name="Zone" type="xsd:string" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional: defines the zone of a webpart page to add the webpart to
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Index" type="xsd:int" use="optional">
+      <xsd:annotation>
+        <xsd:documentation xml:lang="en">
+          Optional: defines the index of the webpart in the zone
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="FieldRef">
@@ -855,7 +866,7 @@
   <xsd:complexType name="Page">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-        Defines a Page element, to describe a page that will be provisioned into the target Site
+        Defines a Page element, to describe a page that will be provisioned into the target Site. If the Layout attribute is defined, the assumption is made that you're referring/creating a wikipage.
       </xsd:documentation>
     </xsd:annotation>
 
@@ -886,21 +897,18 @@
     <xsd:attribute name="Overwrite" type="xsd:boolean" use="optional" default="false">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          Optional: if set, overwrites an existing page
+          Optional: if set, overwrites an existing page in the case of a wikipage. 
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
 
-    <xsd:attribute name="Layout" type="WIKIPAGELAYOUT" use="required">
+    <xsd:attribute name="Layout" type="WIKIPAGELAYOUT" use="optional">
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
-          Required: sets the required layout of the wikipage
+          Optional: If defined, child webpart elements need the row and column attributes set
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
-
-
-
   </xsd:complexType>
 
   <xsd:complexType name="File">

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201504Formatter.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201504Formatter.cs
@@ -371,51 +371,61 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             if (template.Pages != null && template.Pages.Count > 0)
             {
                 var pages = new List<V201504.Page>();
-                foreach(var page in template.Pages)
+                foreach (var page in template.Pages)
                 {
-                    var pageLayout = WIKIPAGELAYOUT.OneColumn;
-                    switch (page.Layout)
+                    var schemaPage = new V201504.Page();
+
+                    if (page.Layout.HasValue)
                     {
-                        case WikiPageLayout.OneColumn:
-                            pageLayout = WIKIPAGELAYOUT.OneColumn;
-                            break;
-                        case WikiPageLayout.OneColumnSideBar:
-                            pageLayout = WIKIPAGELAYOUT.OneColumnSidebar;
-                            break;
-                        case WikiPageLayout.TwoColumns:
-                            pageLayout = WIKIPAGELAYOUT.TwoColumns;
-                            break;
-                        case WikiPageLayout.TwoColumnsHeader:
-                            pageLayout = WIKIPAGELAYOUT.TwoColumnsHeader;
-                            break;
-                        case WikiPageLayout.TwoColumnsHeaderFooter:
-                            pageLayout = WIKIPAGELAYOUT.TwoColumnsHeaderFooter;
-                            break;
-                        case WikiPageLayout.ThreeColumns:
-                            pageLayout = WIKIPAGELAYOUT.ThreeColumns;
-                            break;
-                        case WikiPageLayout.ThreeColumnsHeader:
-                            pageLayout = WIKIPAGELAYOUT.ThreeColumnsHeader;
-                            break;
-                        case WikiPageLayout.ThreeColumnsHeaderFooter:
-                            pageLayout = WIKIPAGELAYOUT.ThreeColumnsHeaderFooter;
-                            break;
-                    }
-                    var webparts = (from wp in page.WebParts
-                        select new V201504.WebPart
+
+                        var pageLayout = WIKIPAGELAYOUT.OneColumn;
+                        switch (page.Layout)
                         {
-                            Column = (int) wp.Column,
-                            Row = (int) wp.Row,
-                            Contents = wp.Contents,
-                            Title = wp.Title
-                        }).ToArray();
-                    pages.Add(new V201504.Page()
-                    {
-                        Layout = pageLayout,
-                        Overwrite = page.Overwrite, 
-                        Url = page.Url,
-                        WebParts = webparts
-                    });
+                            case WikiPageLayout.OneColumn:
+                                pageLayout = WIKIPAGELAYOUT.OneColumn;
+                                break;
+                            case WikiPageLayout.OneColumnSideBar:
+                                pageLayout = WIKIPAGELAYOUT.OneColumnSidebar;
+                                break;
+                            case WikiPageLayout.TwoColumns:
+                                pageLayout = WIKIPAGELAYOUT.TwoColumns;
+                                break;
+                            case WikiPageLayout.TwoColumnsHeader:
+                                pageLayout = WIKIPAGELAYOUT.TwoColumnsHeader;
+                                break;
+                            case WikiPageLayout.TwoColumnsHeaderFooter:
+                                pageLayout = WIKIPAGELAYOUT.TwoColumnsHeaderFooter;
+                                break;
+                            case WikiPageLayout.ThreeColumns:
+                                pageLayout = WIKIPAGELAYOUT.ThreeColumns;
+                                break;
+                            case WikiPageLayout.ThreeColumnsHeader:
+                                pageLayout = WIKIPAGELAYOUT.ThreeColumnsHeader;
+                                break;
+                            case WikiPageLayout.ThreeColumnsHeaderFooter:
+                                pageLayout = WIKIPAGELAYOUT.ThreeColumnsHeaderFooter;
+                                break;
+                        }
+                        schemaPage.Layout = pageLayout;
+                        schemaPage.Overwrite = page.Overwrite;
+                    }
+                    schemaPage.WebParts = (from wp in page.WebParts
+                                           select new V201504.WebPart
+                                           {
+                                               ColumnSpecified = wp.Column.HasValue,
+                                               Column = wp.Column.HasValue ? (int)wp.Column.Value : 0,
+                                               RowSpecified = wp.Row.HasValue,
+                                               Row = wp.Row.HasValue ? (int)wp.Row.Value : 0,
+                                               Contents = wp.Contents,
+                                               Title = wp.Title,
+                                               Zone = wp.Zone,
+                                               IndexSpecified = wp.Index.HasValue,
+                                               Index = wp.Index.HasValue ? (int)wp.Index.Value : 0
+                                           }).ToArray();
+
+                    schemaPage.Url = page.Url;
+
+                    pages.Add(schemaPage);
                 }
                 result.Pages = pages.ToArray();
             }
@@ -726,46 +736,63 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
             {
                 foreach (var page in source.Pages)
                 {
-                    var pageLayout = WikiPageLayout.OneColumn;
-                    switch (page.Layout)
+
+                    if (page.LayoutSpecified)
                     {
-                        case WIKIPAGELAYOUT.OneColumn:
-                            pageLayout = WikiPageLayout.OneColumn;
-                            break;
-                        case WIKIPAGELAYOUT.OneColumnSidebar:
-                            pageLayout = WikiPageLayout.OneColumnSideBar;
-                            break;
-                        case WIKIPAGELAYOUT.TwoColumns:
-                            pageLayout = WikiPageLayout.TwoColumns;
-                            break;
-                        case WIKIPAGELAYOUT.TwoColumnsHeader:
-                            pageLayout = WikiPageLayout.TwoColumnsHeader;
-                            break;
-                        case WIKIPAGELAYOUT.TwoColumnsHeaderFooter:
-                            pageLayout = WikiPageLayout.TwoColumnsHeaderFooter;
-                            break;
-                        case WIKIPAGELAYOUT.ThreeColumns:
-                            pageLayout = WikiPageLayout.ThreeColumns;
-                            break;
-                        case WIKIPAGELAYOUT.ThreeColumnsHeader:
-                            pageLayout = WikiPageLayout.ThreeColumnsHeader;
-                            break;
-                        case WIKIPAGELAYOUT.ThreeColumnsHeaderFooter:
-                            pageLayout = WikiPageLayout.ThreeColumnsHeaderFooter;
-                            break;
+                        var pageLayout = WikiPageLayout.OneColumn;
+                        switch (page.Layout)
+                        {
+                            case WIKIPAGELAYOUT.OneColumn:
+                                pageLayout = WikiPageLayout.OneColumn;
+                                break;
+                            case WIKIPAGELAYOUT.OneColumnSidebar:
+                                pageLayout = WikiPageLayout.OneColumnSideBar;
+                                break;
+                            case WIKIPAGELAYOUT.TwoColumns:
+                                pageLayout = WikiPageLayout.TwoColumns;
+                                break;
+                            case WIKIPAGELAYOUT.TwoColumnsHeader:
+                                pageLayout = WikiPageLayout.TwoColumnsHeader;
+                                break;
+                            case WIKIPAGELAYOUT.TwoColumnsHeaderFooter:
+                                pageLayout = WikiPageLayout.TwoColumnsHeaderFooter;
+                                break;
+                            case WIKIPAGELAYOUT.ThreeColumns:
+                                pageLayout = WikiPageLayout.ThreeColumns;
+                                break;
+                            case WIKIPAGELAYOUT.ThreeColumnsHeader:
+                                pageLayout = WikiPageLayout.ThreeColumnsHeader;
+                                break;
+                            case WIKIPAGELAYOUT.ThreeColumnsHeaderFooter:
+                                pageLayout = WikiPageLayout.ThreeColumnsHeaderFooter;
+                                break;
+                        }
+
+                        result.Pages.Add(new Model.Page(page.Url, page.Overwrite, pageLayout,
+                            (page.WebParts != null ?
+                                (from wp in page.WebParts
+                                 select new Model.WebPart
+                                 {
+                                     Title = wp.Title,
+                                     Column = (uint)wp.Column,
+                                     Row = (uint)wp.Row,
+                                     Contents = wp.Contents
+
+                                 }).ToList() : null)));
                     }
-
-                    result.Pages.Add(new Model.Page(page.Url, page.Overwrite, pageLayout,
-                        (page.WebParts != null ?
-                            (from wp in page.WebParts
-                             select new Model.WebPart
-                             {
-                                 Title = wp.Title,
-                                 Column = (uint)wp.Column,
-                                 Row = (uint)wp.Row,
-                                 Contents = wp.Contents
-
-                             }).ToList() : null)));
+                    else
+                    {
+                        result.Pages.Add(new Model.Page(page.Url,
+                           (page.WebParts != null ?
+                                (from wp in page.WebParts
+                                 select new Model.WebPart
+                                 {
+                                     Title = wp.Title,
+                                     Zone = wp.Zone,
+                                     Index = (uint)wp.Index,
+                                     Contents = wp.Contents
+                                 }).ToList() : null)));
+                    }
                 }
             }
 


### PR DESCRIPTION
Updated webpart element in schema to allow for Zone and Index parameter to facilitate provisioning web parts to existing webpart pages.
Made layout an optional attribute on the page element allowing for specifying webpart pages (to deploy a webpart page, use the File element in the schema)
Fixes some small issue with creating new wikipages through the Page element.