### PR TITLE
Cmdlet updates and new token for tokenparser

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core.Tests/Framework/ObjectHandlers/ObjectTermGroupsTests.cs
@@ -1,18 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Taxonomy;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OfficeDevPnP.Core.Framework.ObjectHandlers;
-using OfficeDevPnP.Core.Framework.Provisioning.Connectors;
 using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers;
-using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
-using ContentType = OfficeDevPnP.Core.Framework.Provisioning.Model.ContentType;
 using Term = OfficeDevPnP.Core.Framework.Provisioning.Model.Term;
 using TermGroup = OfficeDevPnP.Core.Framework.Provisioning.Model.TermGroup;
 using TermSet = OfficeDevPnP.Core.Framework.Provisioning.Model.TermSet;

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Publishing;
 using Microsoft.SharePoint.Client.Taxonomy;
+using OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -81,6 +82,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                     modelTermSet.ID = Guid.NewGuid();
                                 }
                                 set = group.CreateTermSet(modelTermSet.Name.ToParsedString(), modelTermSet.ID, modelTermSet.Language ?? termStore.DefaultLanguage);
+                                TokenParser.AddToken(new TermSetIdToken(web, modelTermGroup.Name, modelTermSet.Name, modelTermSet.ID));
                                 newTermSet = true;
 
                                 set.Description = modelTermSet.Description;
@@ -98,6 +100,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             modelTermSet.ID = Guid.NewGuid();
                         }
                         set = group.CreateTermSet(modelTermSet.Name.ToParsedString(), modelTermSet.ID, modelTermSet.Language ?? termStore.DefaultLanguage);
+                        TokenParser.AddToken(new TermSetIdToken(web, modelTermGroup.Name, modelTermSet.Name, modelTermSet.ID));
                         newTermSet = true;
                         termStore.CommitAll();
                         web.Context.Load(set);
@@ -119,7 +122,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         var sortedTerms = modelTermSet.Terms.OrderBy(t => t.CustomSortOrder);
 
                         var customSortString = sortedTerms.Aggregate(string.Empty, (a, i) => a + i.ID.ToString() + ":");
-                        customSortString = customSortString.TrimEnd(new [] {':'});
+                        customSortString = customSortString.TrimEnd(new[] { ':' });
 
                         set.CustomSortOrder = customSortString;
                         termStore.CommitAll();

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermSetIdToken.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenDefinitions/TermSetIdToken.cs
@@ -1,0 +1,24 @@
+using Microsoft.SharePoint.Client;
+using System;
+
+namespace OfficeDevPnP.Core.Framework.ObjectHandlers.TokenDefinitions
+{
+    public class TermSetIdToken : TokenDefinition
+    {
+        private readonly string _value = null;
+        public TermSetIdToken(Web web, string groupName, string termsetName, Guid id)
+            : base(web, string.Format("{{termsetid:{0}:{1}}}", groupName, termsetName))
+        {
+            _value = id.ToString();
+        }
+
+        public override string GetReplaceValue()
+        {
+            if (string.IsNullOrEmpty(CacheValue))
+            {
+                CacheValue = _value;
+            }
+            return CacheValue;
+        }
+    }
+}

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -336,6 +336,7 @@
     <Compile Include="Framework\Provisioning\ObjectHandlers\ProvisioningTemplateCreationInformation.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\SiteToTemplateConversion.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\KeywordsTermStoreIdToken.cs" />
+    <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\TermSetIdToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ParameterToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\ListUrlToken.cs" />
     <Compile Include="Framework\Provisioning\ObjectHandlers\TokenDefinitions\SiteCollectionTermStoreId.cs" />

--- a/Solutions/PowerShell.Commands/Commands/Admin/GetTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/GetTenantSite.cs
@@ -13,9 +13,7 @@ namespace OfficeDevPnP.PowerShell.Commands
 
     [Cmdlet(VerbsCommon.Get, "SPOTenantSite", SupportsShouldProcess = true)]
     [CmdletHelp(@"Office365 only: Uses the tenant API to retrieve site information.
-
-You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) with Connect-SPOnline in order to use this command. 
-", Details = "Requires a connection to a SharePoint Tenant Admin site.", Category = "Tenant Administration")]
+", Details = "", Category = "Tenant Administration")]
     [CmdletExample(Code = @"
 PS:> Get-SPOTenantSite", Remarks = "Returns all site collections")]
     [CmdletExample(Code = @"

--- a/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/GetWebTemplates.cs
@@ -7,10 +7,7 @@ using System.Management.Automation;
 namespace OfficeDevPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Get, "SPOWebTemplates")]
-    [CmdletHelp(@"Office365 only: Returns the available web templates.
-
-You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) with Connect-SPOnline in order to use this command. 
-", Category = "Tenant Administration")]
+    [CmdletHelp(@"Office365 only: Returns the available web templates.", Category = "Tenant Administration")]
     [CmdletExample(
         Code = @"PS:> Get-SPOWebTemplates")]
     [CmdletExample(

--- a/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
@@ -63,7 +63,7 @@ available quota.
         [Parameter(Mandatory = false)]
         public SwitchParameter Wait;
 
-        protected override void ProcessRecord()
+        protected override void ExecuteCmdlet()
         {
             Tenant.CreateSiteCollection(Url, Title, Owner, Template, (int)StorageQuota, (int)StorageQuotaWarningLevel, TimeZone, (int)ResourceQuota, (int)ResourceQuotaWarningLevel, Lcid, RemoveDeletedSite, Wait);
         }

--- a/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/NewTenantSite.cs
@@ -9,10 +9,7 @@ namespace OfficeDevPnP.PowerShell.Commands
     [Cmdlet(VerbsCommon.New, "SPOTenantSite")]
     [CmdletHelp("Office365 only: Creates a new site collection for the current tenant", DetailedDescription = @"
 The New-SPOTenantSite cmdlet creates a new site collection for the current company. However, creating a new SharePoint
-Online site collection fails if a deleted site with the same URL exists in the Recycle Bin.
-
-You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) with Connect-SPOnline in order to use this command. 
-", Details = "Office365 only", Category = "Tenant Administration")]
+Online site collection fails if a deleted site with the same URL exists in the Recycle Bin.", Details = "Office365 only", Category = "Tenant Administration")]
     public class NewTenantSite : SPOAdminCmdlet
     {
         [Parameter(Mandatory = true)]

--- a/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
@@ -28,7 +28,7 @@ namespace OfficeDevPnP.PowerShell.Commands
         [Parameter(Mandatory = false, HelpMessage = "Do not ask for confirmation.")]
         public SwitchParameter Force;
 
-        protected override void ProcessRecord()
+        protected override void ExecuteCmdlet()
         {
             if (Force || ShouldContinue(string.Format(Resources.RemoveSiteCollection0, Url), Resources.Confirm))
             {

--- a/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/RemoveTenantSite.cs
@@ -8,10 +8,7 @@ using Resources = OfficeDevPnP.PowerShell.Commands.Properties.Resources;
 namespace OfficeDevPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Remove, "SPOTenantSite", ConfirmImpact = ConfirmImpact.High, SupportsShouldProcess = true)]
-    [CmdletHelp("Office365 only: Removes a site collection from the current tenant", DetailedDescription = @"
-
-You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) with Connect-SPOnline in order to use this command. 
-", Details = "Office365 only", Category = "Tenant Administration")]
+    [CmdletHelp("Office365 only: Removes a site collection from the current tenant", DetailedDescription = "", Details = "Office365 only", Category = "Tenant Administration")]
     public class RemoveSite : SPOAdminCmdlet
     {
         [Parameter(Mandatory = true, Position=0, ValueFromPipeline=true)]

--- a/Solutions/PowerShell.Commands/Commands/Admin/SetTenantSite.cs
+++ b/Solutions/PowerShell.Commands/Commands/Admin/SetTenantSite.cs
@@ -8,10 +8,7 @@ using OfficeDevPnP.PowerShell.Commands.Base;
 namespace OfficeDevPnP.PowerShell.Commands
 {
     [Cmdlet(VerbsCommon.Set, "SPOTenantSite")]
-    [CmdletHelp(@"Office365 only: Uses the tenant API to set site information.
-
-You must connect to the admin website (https://:<tenant>-admin.sharepoint.com) with Connect-SPOnline in order to use this command. 
-", Details = "Requires a connection to a SharePoint Tenant Admin site.", Category = "Tenant Administration")]
+    [CmdletHelp(@"Office365 only: Uses the tenant API to set site information.", Details = "", Category = "Tenant Administration")]
     public class SetTenantSite : SPOAdminCmdlet
     {
         [Parameter(Mandatory = false, HelpMessage = "The URL of the site", Position=0, ValueFromPipeline=true)]

--- a/Solutions/PowerShell.Commands/Commands/Base/SPOAdminCmdlet.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOAdminCmdlet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Management.Automation;
 using Microsoft.Online.SharePoint.TenantAdministration;
 using Microsoft.PowerShell.Commands;
 using Microsoft.SharePoint.Client;
@@ -35,21 +36,18 @@ namespace OfficeDevPnP.PowerShell.Commands.Base
             {
                 throw new InvalidOperationException(Resources.NoConnection);
             }
-            if (SPOnlineConnection.CurrentConnection.ConnectionType != ConnectionType.TenantAdmin)
-            {
-                Uri uri = new Uri(this.ClientContext.Url);
-                var urlParts = uri.Authority.Split(new[] { '.' });
-                if (!urlParts[0].EndsWith("-admin"))
-                {
-                    var adminUrl = string.Format("https://{0}-admin.{1}.{2}", urlParts[0], urlParts[1], urlParts[2]);
 
-                    SPOnlineConnection.CurrentConnection.Context = this.ClientContext.Clone(adminUrl);
-                }
-                else
-                {
-                    throw new InvalidOperationException(Resources.CurrentSiteIsNoTenantAdminSite);
-                }
+            SPOnlineConnection.CurrentConnection.CacheContext();
+
+            Uri uri = new Uri(this.ClientContext.Url);
+            var urlParts = uri.Authority.Split(new[] { '.' });
+            if (!urlParts[0].EndsWith("-admin"))
+            {
+                var adminUrl = string.Format("https://{0}-admin.{1}.{2}", urlParts[0], urlParts[1], urlParts[2]);
+
+                SPOnlineConnection.CurrentConnection.Context = this.ClientContext.Clone(adminUrl);
             }
+            
         }
 
         protected override void EndProcessing()

--- a/Solutions/PowerShell.Commands/Commands/Base/SPOCmdlet.cs
+++ b/Solutions/PowerShell.Commands/Commands/Base/SPOCmdlet.cs
@@ -78,6 +78,7 @@ namespace OfficeDevPnP.PowerShell.Commands
             }
             catch (Exception ex)
             {
+                SPOnlineConnection.CurrentConnection.RestoreCachedContext();
                 WriteError(new ErrorRecord(ex, "EXCEPTION", ErrorCategory.WriteError,null));
             }
         }

--- a/Solutions/PowerShell.Commands/changelog.md
+++ b/Solutions/PowerShell.Commands/changelog.md
@@ -1,5 +1,7 @@
 # OfficeDevPnP.PowerShell Changelog #
 
+**2015-04-20**
+* Admin cmdlets: Get-SPOTenantSite, New-SPOTenantSite, Remove-SPOTenantSite, Set-SPOTenantSite and Get-SPOWebTemplates now automatically switch context. This means that you don't have to connect to https://<tenant>-admin.sharepoint.com first in order to execute them.
 **2015-04-08**
 * Added Apply-SPOProvisioningTemplate cmdlet
 * Added Get-SPOPRovisioningTemplate cmdlet


### PR DESCRIPTION
Tenant Admin cmdlets now automatically switch context to the tenant admin site. No need to connect to https://<tenant>-admin.sharepoint.com first anymore if the current credentials have tenant admin rights.

Implemented the {termsetid:<path>} token for use in provisioning templates. The format is {termsetid:groupname:termsetname}, e.g. {termsetid:people:department}. This token, together with the {sitecollectiontermstoreid} token, allows you to provision taxonomy fields declaratively by pointing to either newly created termset, or an existing termset using a token.