### PR TITLE
Fix provisioning engine crash on-prem

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -108,9 +108,9 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             // Information coming from the site
-            template.ComposedLook.AlternateCSS = Tokenize(web.AlternateCssUrl, web.Url);
+            template.ComposedLook.AlternateCSS = web.IsObjectPropertyInstantiated("AlternateCssUrl") ? Tokenize(web.AlternateCssUrl, web.Url) : null;
             template.ComposedLook.MasterPage = Tokenize(web.MasterUrl, web.Url);
-            template.ComposedLook.SiteLogo = Tokenize(web.SiteLogoUrl, web.Url);
+            template.ComposedLook.SiteLogo = web.IsObjectPropertyInstantiated("SiteLogoUrl") ? Tokenize(web.SiteLogoUrl, web.Url) : null;
 
             var theme = web.GetCurrentComposedLook();
 


### PR DESCRIPTION
Web.GetProvisioningTemplate crashes for on-prem blank site, because AlternateCSS and SiteLogoUrl properties are not initiated