### PR TITLE
Bring TaxonomyPicker sample and Component in sync

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
@@ -32,9 +32,8 @@ $(document).ready(function () {
                         function () {
                             $.getScript(layoutsRoot + 'sp.taxonomy.js',
                                 function () {
-                                    //binf the taxonomy picker to the default keywords termset
+                                    //bind the taxonomy picker to the default keywords termset
                                     $('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, useKeywords: true }, context);
-                                    //$('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, termSetId: 'ab483129-7fc6-4b43-8156-8c5ff39cf767' }, context);
                                 });
                         });
                 });

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx
@@ -16,14 +16,14 @@
         <div id="divSPChrome"></div>
         <div style="left: 50%; width: 600px; margin-left: -300px; position: absolute;">
             <table>
-                <%--<tr>
-                    <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Keywords Termset:</h3></td>
+                <tr>
+                    <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Keywords:</h3></td>
                     <td class="ms-formbody" valign="top">
                         <div class="ms-core-form-line" style="margin-bottom: 0px;">
                             <input type="hidden" id="taxPickerKeywords" />
                         </div>
                     </td>
-                </tr>--%>
+                </tr>
                 <tr>
                     <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Continent:</h3></td>
                     <td class="ms-formbody" valign="top">

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
@@ -35,9 +35,9 @@ $(document).ready(function () {
                             $.getScript(layoutsRoot + 'sp.taxonomy.js',
                                 function () {
                                     //bind the taxonomy picker to the default keywords termset
-                                    //$('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, useKeywords: true }, context);
+                                    $('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, useKeywords: true }, context);
 
-                                    $('#taxPickerContinent').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "0cc96f04-d32c-41e7-995f-0401c1f4fda8", levelToShowTerms: 1 }, context, initializeCountryTaxPicker);
+                                    $('#taxPickerContinent').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", levelToShowTerms: 1 }, context, initializeCountryTaxPicker);
                                     taxPickerIndex["#taxPickerContinent"] = 0;
                                 });
                         });
@@ -47,14 +47,14 @@ $(document).ready(function () {
 
 function initializeCountryTaxPicker() {
     if (this._selectedTerms.length > 0) {
-        $('#taxPickerCountry').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "0cc96f04-d32c-41e7-995f-0401c1f4fda8", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 2, useTermSetasRootNode: false }, context, initializeRegionTaxPicker);
+        $('#taxPickerCountry').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 2, useTermSetasRootNode: false }, context, initializeRegionTaxPicker);
         taxPickerIndex["#taxPickerCountry"] = 4;
     }
 }
 
 function initializeRegionTaxPicker() {
     if (this._selectedTerms.length > 0) {
-        $('#taxPickerRegion').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "0cc96f04-d32c-41e7-995f-0401c1f4fda8", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 3, useTermSetasRootNode: false }, context);
+        $('#taxPickerRegion').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 3, useTermSetasRootNode: false }, context);
         taxPickerIndex["#taxPickerRegion"] = 5;
     }
 }

--- a/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol_resources.en.js
+++ b/Samples/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol_resources.en.js
@@ -1,6 +1,7 @@
 ﻿function TaxonomyPickerConsts() { };
 TaxonomyPickerConsts.SUGGESTIONS_HEADER = 'Suggestions';
 TaxonomyPickerConsts.DIALOG_HEADER = 'Select: ';
+TaxonomyPickerConsts.BUTTON_TEXT = 'Select';
 TaxonomyPickerConsts.AMBIGUOUS_ENTRY = 'Ambiguous Entry';
 TaxonomyPickerConsts.DIALOG_ADD_TITLE = 'New items are added under the currently selected item.';
 TaxonomyPickerConsts.DIALOG_ADD_LINK = 'Add New Item';


### PR DESCRIPTION
Update sample and component to be in sync. In order to do
this I reimplemented the Samples functionality to accept
context, callbacks, LevelToShowTerms and Filter.

There is an option in the sample to use term as root node which
I did not reimplement, I don't really see the point of it and
it's not really trivial to do.

I did not update the README's of the projects, it warrants
a discussion of why there are two (now in sync) things in PnP
that does the same thing. Why not remove the sample?