### PR TITLE
Update location of credential prompt in Program.cs

### DIFF
--- a/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/Program.cs
+++ b/Samples/Branding.ApplyBranding/Branding.ApplyBranding.Console/Program.cs
@@ -12,6 +12,7 @@ namespace Contoso.Branding.ApplyBranding
         static void Main(string[] args)
         {
             var isOnline = false;
+            SharePointOnlineCredentials credentials = null;
 
             //check to ensure there's at least one argument
             if (args.Length < 1 || args.Length > 2)
@@ -25,6 +26,10 @@ namespace Contoso.Branding.ApplyBranding
                 if (args[1] == "online")
                 {
                     isOnline = true;
+                    //only relevant if SharePoint Online
+                    var username = GetUserName();
+                    var password = GetPassword();
+                    credentials = new SharePointOnlineCredentials(username, password);
                 }
             }
             
@@ -41,10 +46,6 @@ namespace Contoso.Branding.ApplyBranding
                     {
                         if (isOnline)
                         {
-                            //only relevant if SharePoint Online
-                            var username = GetUserName();
-                            var password = GetPassword();
-                            var credentials = new SharePointOnlineCredentials(username, password);
                             clientContext.Credentials = credentials;
                         }
 


### PR DESCRIPTION
Relocated the prompt for credentials from lines 49-51 to lines 30-32 and added line 15 as a result of the move.  This simplifies the execution of the program by only prompting the executor for credentials once.  Prior to this change it was found that the executor would be prompted for credentials for each site collection configured within the settings.xml file.