### PR TITLE
site provision onprem fix

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -37,11 +37,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 if (existingCT == null)
                 {
                     var newCT = CreateContentType(web, ct);
-                    if(newCT != null)
+                    if (newCT != null)
                     {
                         existingCTs.Add(newCT);
                     }
-                    
+
                 }
                 else
                 {
@@ -49,7 +49,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     {
                         existingCT.DeleteObject();
                         web.Context.ExecuteQueryRetry();
-                        var newCT= CreateContentType(web, ct);
+                        var newCT = CreateContentType(web, ct);
                         if (newCT != null)
                         {
                             existingCTs.Add(newCT);
@@ -115,7 +115,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         ct.ReadOnly,
                         ct.DocumentTemplate,
                         false,
-                            (from fieldLink in ct.FieldLinks
+                            (from fieldLink in ct.FieldLinks.AsEnumerable<FieldLink>()
                              select new FieldRef(fieldLink.Name)
                              {
                                  Id = fieldLink.Id,

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -11,6 +11,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 using OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml;
 using OfficeDevPnP.Core.Utilities;
 using Field = OfficeDevPnP.Core.Framework.Provisioning.Model.Field;
+using SPField = Microsoft.SharePoint.Client.Field;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
@@ -34,8 +35,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             web.Context.Load(existingFields, fs => fs.Include(f => f.Id));
             web.Context.ExecuteQueryRetry();
-            var existingFieldIds = existingFields.Select(l => l.Id).ToList();
-
+            var existingFieldIds = existingFields.AsEnumerable<SPField>().Select(l => l.Id).ToList();
             var fields = template.SiteFields;
 
             foreach (var field in fields)
@@ -98,7 +98,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                             fieldXml = element.ToString();
                         }
                     }
-                  
+
                     // Check if we have version attribute. Remove if exists 
                     if (element.Attribute("Version") != null)
                     {


### PR DESCRIPTION
Fix site provisioning engine crash. ClientQueryable in CSOM v15 does not implement GetEnumerator, so linq queries against collections of client objects throw exceptions