### PR TITLE
fixes - no default termstore and extensibility assembly name

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -72,19 +72,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             // Add TermSetIds
             TaxonomySession session = TaxonomySession.GetTaxonomySession(web.Context);
             var termStore = session.GetDefaultSiteCollectionTermStore();
-            web.Context.Load(termStore.Groups,
-                g => g.Include(
-                    tg => tg.Name,
-                    tg => tg.TermSets.Include(
-                        ts => ts.Name,
-                        ts => ts.Id)
-                ));
+            web.Context.Load(termStore);
             web.Context.ExecuteQueryRetry();
-            foreach (var termGroup in termStore.Groups)
+            if (!termStore.ServerObjectIsNull.Value)
             {
-                foreach (var termSet in termGroup.TermSets)
+                web.Context.Load(termStore.Groups,
+                    g => g.Include(
+                        tg => tg.Name,
+                        tg => tg.TermSets.Include(
+                            ts => ts.Name,
+                            ts => ts.Id)
+                    ));
+                web.Context.ExecuteQueryRetry();
+                foreach (var termGroup in termStore.Groups)
                 {
-                    _tokens.Add(new TermSetIdToken(web, termGroup.Name, termSet.Name, termSet.Id));
+                    foreach (var termSet in termGroup.TermSets)
+                    {
+                        _tokens.Add(new TermSetIdToken(web, termGroup.Name, termSet.Name, termSet.Id));
+                    }
                 }
             }
 

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201505Formatter.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Providers/Xml/XMLPnPSchemaV201505Formatter.cs
@@ -1065,7 +1065,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Providers.Xml
                             result.Providers.Add(
                                 new Model.Provider
                                 {
-                                    Assembly = handlerType.AssemblyQualifiedName,
+                                    Assembly = handlerType.Assembly.FullName,
                                     Type = handlerType.FullName,
                                     Configuration = provider.Configuration != null ? provider.Configuration.ToProviderConfiguration() : null,
                                     Enabled = provider.Enabled,


### PR DESCRIPTION
Small fixes for site provisioning engine:
1- OnPrem token parser crashes when no default term store or no MMS
2- Template parsing ExtensibilityProviders, provider assembly name set to AssemblyQualifiedName (which is type name) instead of assembly name, so ExtensibilityManager cannot create instance of provider