### PR TITLE
Readd taxpicker examples from sample

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx
@@ -24,6 +24,31 @@
                         </div>
                     </td>
                 </tr>
+
+                <tr>
+                    <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Continent:</h3></td>
+                    <td class="ms-formbody" valign="top">
+                        <div class="ms-core-form-line" style="margin-bottom: 0px;">
+                            <asp:HiddenField runat="server" ID="taxPickerContinent" />
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Country:</h3></td>
+                    <td class="ms-formbody" valign="top">
+                        <div class="ms-core-form-line" style="margin-bottom: 0px;">
+                            <asp:HiddenField runat="server" ID="taxPickerCountry" />
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="ms-formlabel" valign="top"><h3 class="ms-standardheader">Region:</h3></td>
+                    <td class="ms-formbody" valign="top">
+                        <div class="ms-core-form-line" style="margin-bottom: 0px;">
+                            <asp:HiddenField runat="server" ID="taxPickerRegion" />
+                        </div>
+                    </td>
+                </tr>
             </table>
 
             <asp:Button runat="server" OnClick="SubmitButton_Click" Text="Submit" />

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx.designer.cs
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Pages/Default.aspx.designer.cs
@@ -40,6 +40,33 @@ namespace Contoso.Core.TaxonomyPickerWeb {
         protected global::System.Web.UI.WebControls.HiddenField taxPickerKeywords;
         
         /// <summary>
+        /// taxPickerContinent control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.HiddenField taxPickerContinent;
+        
+        /// <summary>
+        /// taxPickerCountry control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.HiddenField taxPickerCountry;
+        
+        /// <summary>
+        /// taxPickerRegion control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.HiddenField taxPickerRegion;
+        
+        /// <summary>
         /// SelectedValues control.
         /// </summary>
         /// <remarks>

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
@@ -34,6 +34,17 @@ $(document).ready(function () {
                                 function () {
                                     //bind the taxonomy picker to the default keywords termset
                                     $('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, useKeywords: true }, context);
+
+                                    //bind taxpickers that depend on eachothers choices
+                                    $('#taxPickerContinent').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", levelToShowTerms: 1 }, context, function () {
+                                        $('#taxPickerCountry').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 2 }, context, function () {
+                                            $('#taxPickerRegion').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 3 }, context);
+                                        });
+                                    });
+
+                                    taxPickerIndex["#taxPickerContinent"] = 0;
+                                    taxPickerIndex["#taxPickerCountry"] = 4;
+                                    taxPickerIndex["#taxPickerRegion"] = 5;
                                 });
                         });
                 });

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/app.js
@@ -32,13 +32,16 @@ $(document).ready(function () {
                         function () {
                             $.getScript(layoutsRoot + 'sp.taxonomy.js',
                                 function () {
+                                    //termset used for dependant selection
+                                    var termId = "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae";
+
                                     //bind the taxonomy picker to the default keywords termset
                                     $('#taxPickerKeywords').taxpicker({ isMulti: true, allowFillIn: true, useKeywords: true }, context);
 
                                     //bind taxpickers that depend on eachothers choices
-                                    $('#taxPickerContinent').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", levelToShowTerms: 1 }, context, function () {
-                                        $('#taxPickerCountry').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 2 }, context, function () {
-                                            $('#taxPickerRegion').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: "9df7c69b-267c-4b8b-ab3c-ac5c15cbbfae", filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 3 }, context);
+                                    $('#taxPickerContinent').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: termId, levelToShowTerms: 1 }, context, function () {
+                                        $('#taxPickerCountry').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: termId, filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 2 }, context, function () {
+                                            $('#taxPickerRegion').taxpicker({ isMulti: false, allowFillIn: false, useKeywords: false, termSetId: termId, filterTermId: this._selectedTerms[0].Id, levelToShowTerms: 3 }, context);
                                         });
                                     });
 


### PR DESCRIPTION
When the sample and component got merged the code showing how do to dependant/filterable taxpicker selections was deleted. This PR reintroduces them.