### PR TITLE
Allow DataRows in separate template for 2nd pass

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -322,14 +322,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 #endregion
 
                 #region DataRows
-
-                foreach (var listInfo in createdLists)
+                
+                //Allow DataRows from separate Template (after List instances created and Lookups have been resolved)
+                foreach (var listInstance in template.Lists)
                 {
-                    var listInstance = listInfo.ListInstance;
+                    if (!existingLists.Contains(UrlUtility.Combine(serverRelativeUrl, listInstance.Url)))
+                    {
+                        continue;
+                    }
+
                     if (listInstance.DataRows != null && listInstance.DataRows.Any())
                     {
-                        var list = listInfo.CreatedList;
-                        foreach (var dataRow in listInfo.ListInstance.DataRows)
+                        var list = web.GetListByUrl(UrlUtility.Combine(serverRelativeUrl, listInstance.Url));
+
+                        foreach (var dataRow in listInstance.DataRows)
                         {
                             ListItemCreationInformation listitemCI = new ListItemCreationInformation();
                             var listitem = list.AddItem(listitemCI);

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -333,18 +333,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                     if (listInstance.DataRows != null && listInstance.DataRows.Any())
                     {
+                        
                         var list = web.GetListByUrl(UrlUtility.Combine(serverRelativeUrl, listInstance.Url));
+                        web.Context.Load(list, l => l.ItemCount);
+                        web.Context.ExecuteQueryRetry();
 
-                        foreach (var dataRow in listInstance.DataRows)
+                        //Only add data if List is empty (implying recently created or the addition of a new template with DataRows)
+                        if (list.ItemCount == 0)
                         {
-                            ListItemCreationInformation listitemCI = new ListItemCreationInformation();
-                            var listitem = list.AddItem(listitemCI);
-                            foreach (var dataValue in dataRow.Values)
+                            foreach (var dataRow in listInstance.DataRows)
                             {
-                                listitem[dataValue.Key.ToParsedString()] = dataValue.Value.ToParsedString();
+                                ListItemCreationInformation listitemCI = new ListItemCreationInformation();
+                                var listitem = list.AddItem(listitemCI);
+                                foreach (var dataValue in dataRow.Values)
+                                {
+                                    listitem[dataValue.Key.ToParsedString()] = dataValue.Value.ToParsedString();
+                                }
+                                listitem.Update();
+                                web.Context.ExecuteQueryRetry(); // TODO: Run in batches?
                             }
-                            listitem.Update();
-                            web.Context.ExecuteQueryRetry(); // TODO: Run in batches?
                         }
                     }
                 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/OfficeDevPnP.Core.csproj
@@ -514,11 +514,15 @@
     </WebReferenceUrl>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Framework\Provisioning\BaseTemplates\v16\STS0Template.xml" />
+    <EmbeddedResource Include="Framework\Provisioning\BaseTemplates\v16\STS0Template.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
-    <EmbeddedResource Include="Framework\Provisioning\BaseTemplates\v15\STS0Template.xml" />
+    <EmbeddedResource Include="Framework\Provisioning\BaseTemplates\v15\STS0Template.xml">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>


### PR DESCRIPTION
We really needed ability to apply DataRows *after* Lists are created and Lookup columns resolved (since we are populating Lookup columns in some cases).  The template now drives the application of DataRows - regardless if it is part of the initial List creation template or a separate template.