### PR TITLE
Make GetFile handle exception type instead of english exception message

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FileFolderExtensions.cs
@@ -819,9 +819,9 @@ namespace Microsoft.SharePoint.Client
                 folder.Context.ExecuteQueryRetry();
                 return file;
             }
-            catch (Exception ex)
+            catch (ServerException sex)
             {
-                if (ex.Message == "File Not Found.")
+                if (sex.ServerErrorTypeName == "System.IO.FileNotFoundException")
                 {
                     return null;
                 }


### PR DESCRIPTION
Change from
```if (ex.Message == "File Not Found.")```
to
```if (sex.ServerErrorTypeName == "System.IO.FileNotFoundException")```