### PR TITLE
ObjectHandlers update

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectComposedLook : ObjectHandlerBase
+    internal class ObjectComposedLook : ObjectHandlerBase
     {
 
         public override string Name
@@ -17,17 +17,17 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             get { return "Composed Looks"; }
         }
 
-
+       
 
         public override void ProvisionObjects(Web web, ProvisioningTemplate template)
         {
 
             Log.Info(Constants.LOGGING_SOURCE_FRAMEWORK_PROVISIONING, CoreResources.Provisioning_ObjectHandlers_ComposedLooks);
-            if (template.ComposedLook != null && 
+            if (template.ComposedLook != null &&
                 !template.ComposedLook.Equals(ComposedLook.Empty))
             {
                 bool executeQueryNeeded = false;
-                
+
                 // Apply alternate CSS
                 if (!string.IsNullOrEmpty(template.ComposedLook.AlternateCSS))
                 {
@@ -36,7 +36,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     web.Update();
                     executeQueryNeeded = true;
                 }
-                
+
                 // Apply Site logo
                 if (!string.IsNullOrEmpty(template.ComposedLook.SiteLogo))
                 {
@@ -89,7 +89,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         }
 
         public override ProvisioningTemplate CreateEntities(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
-        {            
+        {
             // Load object if not there
             bool executeQueryNeeded = false;
             if (!web.IsPropertyAvailable("Url"))
@@ -161,7 +161,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         else
                         {
                             spConnectorRoot = spConnector;
-                        }                        
+                        }
 
                         // Download the theme/branding specific files
                         DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, web.AlternateCssUrl);
@@ -291,6 +291,32 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         private ProvisioningTemplate CleanupEntities(ProvisioningTemplate template, ProvisioningTemplate baseTemplate)
         {
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = (template.ComposedLook != null && !template.ComposedLook.Equals(ComposedLook.Empty));
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                var theme = web.GetCurrentComposedLook();
+                if (theme.IsCustomComposedLook)
+                {
+                    _willExtract = true;
+                }
+                else
+                {
+                    _willExtract = false;
+                }
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -10,7 +10,7 @@ using ContentType = OfficeDevPnP.Core.Framework.Provisioning.Model.ContentType;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectContentType : ObjectHandlerBase
+    internal class ObjectContentType : ObjectHandlerBase
     {
         public override string Name
         {
@@ -148,6 +148,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.ContentTypes.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = true;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Entities;
 using OfficeDevPnP.Core.Framework.ObjectHandlers;
@@ -7,7 +8,7 @@ using OfficeDevPnP.Core.Utilities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectCustomActions : ObjectHandlerBase
+    internal class ObjectCustomActions : ObjectHandlerBase
     {
         public override string Name
         {
@@ -175,6 +176,28 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             customAction.CommandUIExtension = userCustomAction.CommandUIExtension;
 
             return customAction;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.CustomActions.SiteCustomActions.Any() || template.CustomActions.WebCustomActions.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                var context = web.Context as ClientContext;
+                var webCustomActions = web.GetCustomActions();
+                var siteCustomActions = context.Site.GetCustomActions();
+
+                _willExtract = webCustomActions.Any() || siteCustomActions.Any();
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectExtensibilityProviders.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Framework.ObjectHandlers;
 using OfficeDevPnP.Core.Framework.Provisioning.Extensibility;
@@ -53,6 +54,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Providers.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFeatures.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFeatures.cs
@@ -9,7 +9,7 @@ using OfficeDevPnP.Core.Utilities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectFeatures : ObjectHandlerBase
+    internal class ObjectFeatures : ObjectHandlerBase
     {
         public override string Name
         {
@@ -184,5 +184,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return template;
         }
 
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Features.SiteFeatures.Any() || template.Features.WebFeatures.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = true;
+            }
+            return _willExtract.Value;
+        }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -15,7 +15,7 @@ using SPField = Microsoft.SharePoint.Client.Field;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectField : ObjectHandlerBase
+    internal class ObjectField : ObjectHandlerBase
     {
         public override string Name
         {
@@ -136,6 +136,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.SiteFields.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = true;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -11,7 +11,7 @@ using File = Microsoft.SharePoint.Client.File;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectFiles : ObjectHandlerBase
+    internal class ObjectFiles : ObjectHandlerBase
     {
         public override string Name
         {
@@ -158,6 +158,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Files.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -5,15 +5,25 @@ using System;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public abstract class ObjectHandlerBase
+    internal delegate bool ShouldProvisionTest(Web web, ProvisioningTemplate template);
+
+    internal abstract class ObjectHandlerBase
     {
+        internal bool? _willExtract;
+        internal bool? _willProvision;
+
         private bool _reportProgress = true;
         public abstract string Name { get; }
+
         public bool ReportProgress
         {
             get { return _reportProgress; }
             set { _reportProgress = value; }
         }
+
+        public abstract bool WillProvision(Web web, ProvisioningTemplate template);
+
+        public abstract bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo);
 
         public abstract void ProvisionObjects(Web web, ProvisioningTemplate template);
 

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -16,7 +16,7 @@ using View = OfficeDevPnP.Core.Framework.Provisioning.Model.View;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectListInstance : ObjectHandlerBase
+    internal class ObjectListInstance : ObjectHandlerBase
     {
 
         public override string Name
@@ -95,7 +95,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                                 if (list.EnableMinorVersions)
                                 {
                                     createdList.MajorWithMinorVersionsLimit = list.MinorVersionLimit; // Set only if enabled, otherwise you'll get exception due setting value to zero.
-                                    
+
                                     // DraftVisibilityType.Approver is available only when the EnableModeration option of the list is true
                                     if (DraftVisibilityType.Approver ==
                                         (DraftVisibilityType)list.DraftVersionVisibility)
@@ -428,7 +428,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     if (creationInfo.BaseTemplate != null)
                     {
                         // Check if we need to skip this list...if so let's do it before we gather all the other information for this list...improves performance
-                        index = creationInfo.BaseTemplate.Lists.FindIndex(f => f.Url.Equals(item.RootFolder.ServerRelativeUrl.Substring(serverRelativeUrl.Length+1)) &&
+                        index = creationInfo.BaseTemplate.Lists.FindIndex(f => f.Url.Equals(item.RootFolder.ServerRelativeUrl.Substring(serverRelativeUrl.Length + 1)) &&
                                                                   f.TemplateType.Equals(item.BaseTemplate));
                     }
 
@@ -569,6 +569,30 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Lists.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                ListCollection collList = web.Lists;
+                var lists = web.Context.LoadQuery(collList.Where(l => l.Hidden));
+
+                web.Context.ExecuteQuery();
+
+                _willExtract = lists.Any();
+            }
+            return _willExtract.Value;
+
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectLookupFields.cs
@@ -9,7 +9,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectLookupFields : ObjectHandlerBase
+    internal class ObjectLookupFields : ObjectHandlerBase
     {
         public override string Name
         {
@@ -133,6 +133,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                     }
                 }
             }
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.SiteFields.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -8,7 +8,7 @@ using OfficeDevPnP.Core.Utilities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectPages : ObjectHandlerBase
+    internal class ObjectPages : ObjectHandlerBase
     {
         public override string Name
         {
@@ -118,6 +118,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         {
 
             return template;
+        }
+
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Pages.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPersistTemplateInfo.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPersistTemplateInfo.cs
@@ -11,7 +11,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectPersistTemplateInfo : ObjectHandlerBase
+    internal class ObjectPersistTemplateInfo : ObjectHandlerBase
     {
         public override string Name
         {
@@ -43,6 +43,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         public override Model.ProvisioningTemplate CreateEntities(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = true;
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPropertyBagEntry.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectPropertyBagEntry.cs
@@ -7,7 +7,7 @@ using OfficeDevPnP.Core.Utilities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectPropertyBagEntry : ObjectHandlerBase
+    internal class ObjectPropertyBagEntry : ObjectHandlerBase
     {
         public override string Name
         {
@@ -131,5 +131,24 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return hashSet.Select(x => x);
         }
 
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.PropertyBagEntries.Any();;
+            }
+            return _willProvision.Value;
+           
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = true;
+            }
+            return _willExtract.Value;
+        }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRetrieveTemplateInfo.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectRetrieveTemplateInfo.cs
@@ -6,7 +6,7 @@ using OfficeDevPnP.Core.Framework.Provisioning.Model;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectRetrieveTemplateInfo : ObjectHandlerBase
+    internal class ObjectRetrieveTemplateInfo : ObjectHandlerBase
     {
         public override string Name
         {
@@ -68,6 +68,26 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = false;
+            }
+            return _willProvision.Value;
+
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = false;
+            }
+            return _willExtract.Value;
+
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSitePolicy.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSitePolicy.cs
@@ -16,7 +16,7 @@ using SPField = Microsoft.SharePoint.Client.Field;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectSitePolicy : ObjectHandlerBase
+    internal class ObjectSitePolicy : ObjectHandlerBase
     {
         public override string Name
         {
@@ -47,6 +47,26 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return template;
         }
 
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.SitePolicy != null;
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                var sitePolicyEntity = web.GetAppliedSitePolicy();
+
+                _willExtract = sitePolicyEntity != null;
+            }
+            return _willExtract.Value;
+        }
     }
 }
 

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -8,7 +8,7 @@ using User = OfficeDevPnP.Core.Framework.Provisioning.Model.User;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectSiteSecurity : ObjectHandlerBase
+    internal class ObjectSiteSecurity : ObjectHandlerBase
     {
         public override string Name
         {
@@ -197,6 +197,25 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             }
 
             return template;
+        }
+
+        public override bool WillProvision(Web web, ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.Security.AdditionalAdministrators.Any() || template.Security.AdditionalMembers.Any() || template.Security.AdditionalOwners.Any() || template.Security.AdditionalVisitors.Any();    
+            }
+            return _willProvision.Value;
+
+        }
+
+        public override bool WillExtract(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = true;
+            }
+            return _willExtract.Value;
         }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -14,7 +14,7 @@ using OfficeDevPnP.Core.Utilities;
 
 namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
-    public class ObjectTermGroups : ObjectHandlerBase
+    internal class ObjectTermGroups : ObjectHandlerBase
     {
 
         public override string Name
@@ -432,5 +432,23 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
             return termsToReturn;
         }
 
+
+        public override bool WillProvision(Web web, Model.ProvisioningTemplate template)
+        {
+            if (!_willProvision.HasValue)
+            {
+                _willProvision = template.TermGroups.Any();
+            }
+            return _willProvision.Value;
+        }
+
+        public override bool WillExtract(Web web, Model.ProvisioningTemplate template,  ProvisioningTemplateCreationInformation creationInfo)
+        {
+            if (!_willExtract.HasValue)
+            {
+                _willExtract = creationInfo.IncludeSiteCollectionTermGroup || creationInfo.IncludeAllTermGroups;
+            }
+            return _willExtract.Value;
+        }
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -14,12 +14,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 {
     internal class SiteToTemplateConversion
     {
-        
         /// <summary>
         /// Actual implementation of extracting configuration from existing site.
         /// </summary>
         /// <param name="web"></param>
-        /// <param name="baseTemplate"></param>
+        /// <param name="creationInfo"></param>
         /// <returns></returns>
         internal ProvisioningTemplate GetRemoteTemplate(Web web, ProvisioningTemplateCreationInformation creationInfo)
         {
@@ -56,16 +55,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             int step = 1;
 
-            var count = objectHandlers.Count(o => o.ReportProgress);
+            var count = objectHandlers.Count(o => o.ReportProgress && o.WillExtract(web,template,creationInfo));
 
             foreach (var handler in objectHandlers)
             {
-                if (handler.ReportProgress && progressDelegate != null)
+                if (handler.WillExtract(web, template, creationInfo))
                 {
-                    progressDelegate(handler.Name, step, count);
-                    step++;
+                    if (handler.ReportProgress && progressDelegate != null)
+                    {
+                        progressDelegate(handler.Name, step, count);
+                        step++;
+                    }
+                    template = handler.CreateEntities(web, template, creationInfo);
                 }
-                template = handler.CreateEntities(web, template, creationInfo);
             }
             Log.Info(Constants.LOGGING_SOURCE_FRAMEWORK_PROVISIONING, CoreResources.Provisioning_ObjectHandlers_FinishExtraction);
             return template;
@@ -75,7 +77,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
         /// Actual implementation of the apply templates
         /// </summary>
         /// <param name="web"></param>
-        /// <param name="template"></param>
+        /// <param name="provisioningInfo"></param>
         internal void ApplyRemoteTemplate(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation provisioningInfo)
         {
             ProvisioningProgressDelegate progressDelegate = null;
@@ -108,16 +110,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             int step = 1;
 
-            var count = objectHandlers.Count(o => o.ReportProgress);
+            var count = objectHandlers.Count(o => o.ReportProgress && o.WillProvision(web, template));
 
             foreach (var handler in objectHandlers)
             {
-                if (handler.ReportProgress && progressDelegate != null)
+                if (handler.WillProvision(web, template))
                 {
-                    progressDelegate(handler.Name, step, count);
-                    step++;
+                    if (handler.ReportProgress && progressDelegate != null)
+                    {
+                        progressDelegate(handler.Name, step, count);
+                        step++;
+                    }
+                    handler.ProvisionObjects(web, template);
                 }
-                handler.ProvisionObjects(web, template);
             }
 
             Log.Info(Constants.LOGGING_SOURCE_FRAMEWORK_PROVISIONING, CoreResources.Provisioning_ObjectHandlers_FinishProvisioning);

--- a/Solutions/PowerShell.Commands/Commands/Taxonomy/ExportTermGroupToXml.cs
+++ b/Solutions/PowerShell.Commands/Commands/Taxonomy/ExportTermGroupToXml.cs
@@ -42,12 +42,12 @@ namespace OfficeDevPnP.PowerShell.Commands
 
         protected override void ExecuteCmdlet()
         {
-            var template = new ProvisioningTemplate();
+           // var template = new ProvisioningTemplate();
 
             var templateCi = new ProvisioningTemplateCreationInformation(ClientContext.Web) { IncludeAllTermGroups = true };
 
-            template = new ObjectTermGroups().CreateEntities(ClientContext.Web, template, templateCi);
-
+            var template = ClientContext.Web.GetProvisioningTemplate(templateCi);
+           
             template.Security = null;
             template.Features = null;
             template.CustomActions = null;


### PR DESCRIPTION
Changed objecthandlers to be internal classes instead of public
Implemented a change in the SiteToTemplateConversion class to only execute an objecthandler if there is actually anything to progress. This change means that you will only see progress reported for those artifacts that are defined in the template or those that can be extracted.