### PR TITLE
Bug fixes and documentation update

### DIFF
--- a/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx
+++ b/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx
@@ -4,7 +4,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head runat="server">
-    <title>App Script Part Usage</title>
+    <title>Add-in Script Part Usage</title>
     <script type="text/javascript" src="../Scripts/jquery-1.9.1.js"></script>
     <script type="text/javascript" src="../Scripts/app.js"></script>
 </head>
@@ -13,14 +13,14 @@
  <asp:ScriptManager ID="ScriptManager1" runat="server" EnableCdn="True" />
     <div id="divSPChrome"></div>
     <div style="left: 40px; position: absolute;">
-        <h1>Scenario: Add script app part to host web</h1>
-        In this scenario you'll learn how to inject app script part to host web, which still uses scripts and processes from the provider hosted app without app parts.
+        <h1>Scenario: Add script Add-in part to host web</h1>
+        In this scenario you'll learn how to inject Add-in script part to host web, which still uses scripts and processes from the provider hosted Add-in without Add-in parts.
         <ul style="list-style-type: square;">
-            <li>How to create app script part which is referencing scripts from provider hosted app</li>
-            <li>How to deploy app script web part to be available for use from web part gallery</li>
+            <li>How to create Add-in script part which is referencing scripts from provider hosted app</li>
+            <li>How to deploy Add-in script web part to be available for use from web part gallery</li>
         </ul>
         <br />
-        <i>Notice that technically you could also upload the needed script(s) to the host web from the provider hosted app or during provisioning and reference scripts from there.</i>
+        <i>Notice that technically you could also upload the needed script(s) to the host web from the provider hosted Add-in or during provisioning and reference scripts from there.</i>
         <br />
         <br />       
         <asp:Button runat="server" ID="btnScenario" Text="Run Scenario" OnClick="btnScenario_Click" />

--- a/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
+++ b/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
@@ -85,13 +85,13 @@ namespace Core.AppScriptPartWeb
                     // Just random group name to differentiate it from the rest
                     if (item["FileLeafRef"].ToString().ToLowerInvariant() == "userprofileinformation.webpart")
                     {
-                        item["Group"] = "App Script Part";
+                        item["Group"] = "Add-in Script Part";
                         item.Update();
                         clientContext.ExecuteQuery();
                     }
                 }
 
-                lblStatus.Text = string.Format("App script part has been added to web part gallery. You can find 'User Profile Information' script part under 'App Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
+                lblStatus.Text = string.Format("Add-in script part has been added to web part gallery. You can find 'User Profile Information' script part under 'Add-in Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
             }
         }
     }

--- a/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
+++ b/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
@@ -58,7 +58,7 @@ namespace Core.AppScriptPartWeb
             var spContext = SharePointContextProvider.Current.GetSharePointContext(Context);
             using (var clientContext = spContext.CreateUserClientContextForSPHost())
             {
-                var folder = clientContext.Web.Lists.GetByTitle("Web Part Gallery").RootFolder;
+                var folder = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery").RootFolder;
                 clientContext.Load(folder);
                 clientContext.ExecuteQuery();
 
@@ -75,7 +75,7 @@ namespace Core.AppScriptPartWeb
                 }
 
                 // Let's update the group for just uploaded web part
-                var list = clientContext.Web.Lists.GetByTitle("Web Part Gallery");
+                var list = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery");
                 CamlQuery camlQuery = CamlQuery.CreateAllItemsQuery(100);
                 Microsoft.SharePoint.Client.ListItemCollection items = list.GetItems(camlQuery);
                 clientContext.Load(items);

--- a/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/userprofileinformation.webpart
+++ b/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/userprofileinformation.webpart
@@ -11,7 +11,7 @@
         <property name="Hidden" type="bool">False</property>
         <property name="Description" type="string">Shows user profile information of current user.</property>
         <property name="Content" type="string">&lt;script type="text/javascript" src="https://localhost:44361/scripts/userprofileinformation.js"&gt;&lt;/script&gt;
-&lt;div id="UserProfileAboutMe"&gt;&lt;div&gt;
+&lt;div id="UserProfileAboutMe"&gt;&lt;/div&gt;
 </property>
         <property name="CatalogIconImageUrl" type="string">/_layouts/images/wp_pers.gif</property>
         <property name="Title" type="string">User profile information</property>

--- a/Samples/Core.AppScriptPart/readme.md
+++ b/Samples/Core.AppScriptPart/readme.md
@@ -89,12 +89,13 @@ Adding of the web part to the host web is simply implemented by uploading the we
 var spContext = SharePointContextProvider.Current.GetSharePointContext(Context);
 using (var clientContext = spContext.CreateUserClientContextForSPHost())
 {
-    var folder = clientContext.Web.Lists.GetByTitle("Web Part Gallery").RootFolder;
+    var folder = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery").RootFolder;
     clientContext.Load(folder);
     clientContext.ExecuteQuery();
-    
-    //upload the "OneDrive for Business Usage Guidelines.docx"
-    using (var stream = System.IO.File.OpenRead(Server.MapPath("~/userprofileinformation.webpart")))
+
+    //upload the "userprofileinformation.webpart" file
+    using (var stream = System.IO.File.OpenRead(
+                    Server.MapPath("~/userprofileinformation.webpart")))
     {
         FileCreationInformation fileInfo = new FileCreationInformation();
         fileInfo.ContentStream = stream;
@@ -103,25 +104,25 @@ using (var clientContext = spContext.CreateUserClientContextForSPHost())
         File file = folder.Files.Add(fileInfo);
         clientContext.ExecuteQuery();
     }
-    
-    // Let's update the group for just uplaoded web part
-    var list = clientContext.Web.Lists.GetByTitle("Web Part Gallery");
+
+    // Let's update the group for just uploaded web part
+    var list = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery");
     CamlQuery camlQuery = CamlQuery.CreateAllItemsQuery(100);
     Microsoft.SharePoint.Client.ListItemCollection items = list.GetItems(camlQuery);
     clientContext.Load(items);
     clientContext.ExecuteQuery();
     foreach (var item in items)
     {
-        // Just random group name to diffentiate it from the rest
+        // Just random group name to differentiate it from the rest
         if (item["FileLeafRef"].ToString().ToLowerInvariant() == "userprofileinformation.webpart")
         {
-            item["Group"] = "Add-in Script Part";
+            item["Group"] = "App Script Part";
             item.Update();
             clientContext.ExecuteQuery();
         }
     }
-    
-    lblStatus.Text = string.Format("Add-in script part has been added to web part gallery. You can find 'User Profile Information' script part under 'App Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
+
+   lblStatus.Text = string.Format("App script part has been added to web part gallery. You can find 'User Profile Information' script part under 'App Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
 }
 ```
 

--- a/Samples/Core.AppScriptPart/readme.md
+++ b/Samples/Core.AppScriptPart/readme.md
@@ -116,13 +116,13 @@ using (var clientContext = spContext.CreateUserClientContextForSPHost())
         // Just random group name to differentiate it from the rest
         if (item["FileLeafRef"].ToString().ToLowerInvariant() == "userprofileinformation.webpart")
         {
-            item["Group"] = "App Script Part";
+            item["Group"] = "Add-in Script Part";
             item.Update();
             clientContext.ExecuteQuery();
         }
     }
 
-   lblStatus.Text = string.Format("App script part has been added to web part gallery. You can find 'User Profile Information' script part under 'App Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
+   lblStatus.Text = string.Format("Add-in script part has been added to web part gallery. You can find 'User Profile Information' script part under 'Add-in Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());
 }
 ```
 


### PR DESCRIPTION
Bug fix 1: Updated the reference to the "Web Part Gallery" list from clientContext.Web.Lists to clientContext.Site.RootWeb.Lists so the Add-in may be provisioned to a subsite. Previously, attempting to do this would cause an error since the subsite does not have a "Web Part Gallery" list.

Bug fix 2: Closed the div tag associated with the "UserProfileAboutMe" div. Previously, there was a second open div tag that was causing rendering issues when deploying the Add-in part to a rich content area.

Also, updated documentation to stay in sync with code changes and reference "Add-in" instead of "app" in numerous instances.