### PR TITLE
Resolved error in GetLogEntry if args are null

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/WebExtensions.cs
@@ -1049,16 +1049,17 @@ namespace Microsoft.SharePoint.Client
         /// will be compared with the default base template.
         /// </summary>
         /// <param name="web">Web to get template from</param>
-        /// <param name="connector">Connector that will be used to persist the files retrieved from the template "get"</param>
         /// <param name="creationInfo">Specifies additional settings and/or properties</param>
         /// <returns>ProvisioningTemplate object with generated values from existing site</returns>
         public static ProvisioningTemplate GetProvisioningTemplate(this Web web, ProvisioningTemplateCreationInformation creationInfo)
         {
             return new SiteToTemplateConversion().GetRemoteTemplate(web, creationInfo);
         }
+
         #endregion
 
         #region Output Cache
+
         /// <summary>
         /// Sets output cache on publishing web. The settings can be maintained from UI by visiting url /_layouts/15/sitecachesettings.aspx
         /// </summary>
@@ -1082,7 +1083,7 @@ namespace Microsoft.SharePoint.Client
             web.SetPropertyBagValue("AuthenticatedPageCacheProfileUrl", string.Format(cacheProfileUrl, authenticatedCacheProfileId));
             web.SetPropertyBagValue("EnableDebuggingOutput", debugCacheInformation.ToString());
         }
-        #endregion
 
+        #endregion
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Utilities/Log.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Utilities/Log.cs
@@ -11,6 +11,7 @@ namespace OfficeDevPnP.Core.Utilities
     public static class Log
     {
         #region Public Members
+
         /// <summary>
         /// Increases the current IndentLevel by one.
         /// </summary>
@@ -88,26 +89,33 @@ namespace OfficeDevPnP.Core.Utilities
             var log = GetLogEntry(source, message, args);
             Trace.Fail(log);
         }
+
         #endregion
 
         #region Private Members
+
         /// <summary>
         /// Helper Method to format error messages
         /// </summary>
-        /// <param name="source"></param>
-        /// <param name="message"></param>
-        /// <param name="args"></param>
-        /// <returns></returns>
+        /// <param name="source">Source of the message</param>
+        /// <param name="message">Message to log</param>
+        /// <param name="args">Arguments to used for message completion</param>
+        /// <returns>Log entry</returns>
         private static string GetLogEntry(string source, string message, params object[] args)
         {
             try
             {
+                string msg = string.Empty;
+
                 if (args == null || args.Length == 0)
                 {
-                    message = message.Replace("{", "{{").Replace("}", "}}");
+                    msg = message.Replace("{", "{{").Replace("}", "}}");
+                }
+                else
+                {
+                    msg = String.Format(CultureInfo.CurrentCulture, message, args);
                 }
 
-                string msg = String.Format(CultureInfo.CurrentCulture, message, args);
                 string log = string.Format(CultureInfo.CurrentCulture, "{0} [[{1}]] {2}", DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"), source, msg);
                 return log;
             }
@@ -116,6 +124,7 @@ namespace OfficeDevPnP.Core.Utilities
                 return string.Format("Error while generating log information, {0}", e);
             }
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
1. Fixed method GetLogEntry to handle null args parameter. With previous code, it fails at line
string msg = String.Format(CultureInfo.CurrentCulture, message, args);
if args is null.
2. Removed unneeded parameter "connector" from documentation header of method GetProvisioningTemplate