### PR TITLE
Feature1

### DIFF
--- a/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
+++ b/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
@@ -1,6 +1,10 @@
 ﻿// Register script for MDS if possible
 RegisterModuleInit("CustomInjectedJS.js", SubSiteOverride_Inject); //MDS registration
-SubSiteOverride_Inject(); //non MDS run
+
+// https://github.com/OfficeDev/PnP/issues/564 When publishing feature is enabled, subsite link override fails 
+document.addEventListener("DOMContentLoaded", function (event) {
+    SubSiteOverride_Inject(); //non MDS run
+});
 
 // Actual execution
 function SubSiteOverride_Inject() {

--- a/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
+++ b/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
@@ -1,7 +1,7 @@
 ﻿// Register script for MDS if possible
 RegisterModuleInit("CustomInjectedJS.js", SubSiteOverride_Inject); //MDS registration
 
-// https://github.com/OfficeDev/PnP/issues/564 When publishing feature is enabled, subsite link override fails 
+// https://github.com/OfficeDev/PnP/issues/564 When publishing feature is enabled, subsite link override fails
 document.addEventListener("DOMContentLoaded", function (event) {
     SubSiteOverride_Inject(); //non MDS run
 });


### PR DESCRIPTION
Bug fix #564 - When publishing feature is enabled, subsite link override fails
Ravi & I fixed this bug by waiting for the page to load before the call to subsite_override takes place.