### PR TITLE
Fix provisioning engine for CSOMv15 support + custom action token replacement

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -109,7 +109,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 web.Context.ExecuteQueryRetry();
             }
             // Delta handling
-            List<Guid> targetIds = existingContentType.FieldLinks.Select(c1 => c1.Id).ToList();
+            List<Guid> targetIds = existingContentType.FieldLinks.AsEnumerable().Select(c1 => c1.Id).ToList();
             List<Guid> sourceIds = templateContentType.FieldRefs.Select(c1 => c1.Id).ToList();
 
             var fieldsNotPresentInTarget = sourceIds.Except(targetIds).ToArray();

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -80,7 +80,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                         Remove = customAction.Remove,
                         Rights = customAction.Rights,
                         ScriptBlock = customAction.ScriptBlock.ToParsedString(),
-                        ScriptSrc = customAction.ScriptSrc.ToParsedString(),
+                        ScriptSrc = customAction.ScriptSrc,
                         Sequence = customAction.Sequence,
                         Title = customAction.Title,
                         Url = customAction.Url.ToParsedString()


### PR DESCRIPTION
1) Fixed content types provisioning crash on-premises
2) Provisioning engine should not replace URL tokens in custom action ScriptSrc. When ScriptSrc set to absolute URL causes errors like this and appears as a blank page: 
Microsoft.SharePoint.SPException: Cannot make a cache safe URL for "/siteassets/main.debug.js", file not found. Please verify that the file exists under the layouts directory.   