### PR TITLE
fix for update list on-prem

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -359,8 +359,10 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 l => l.EnableAttachments,
                 l => l.EnableFolderCreation,
                 l => l.EnableMinorVersions,
-                l => l.DraftVersionVisibility,
-                l => l.MajorWithMinorVersionsLimit
+                l => l.DraftVersionVisibility
+#if !CLIENTSDKV15
+                ,l => l.MajorWithMinorVersionsLimit
+#endif
                 );
             web.Context.ExecuteQueryRetry();
 


### PR DESCRIPTION
CSOM v15 does not support MajorWithMinorVersionsLimit so UpdateList crashes on-premises