### PR TITLE
PowerShell installation now allows set up per user or per machine

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/FieldAndContentTypeExtensions.cs
@@ -1360,7 +1360,7 @@ namespace Microsoft.SharePoint.Client
             list.Context.Load(ctCol);
             list.Context.ExecuteQueryRetry();
 
-            var ctIds = ctCol.Select(ct => ct.Id).ToList();
+            var ctIds = ctCol.AsEnumerable().Select(ct => ct.Id).ToList();
 
             // remove the folder content type
             var newOrder = ctIds.Except(ctIds.Where(id => id.StringValue.StartsWith("0x012000")))

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/AzureStorageConnector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -284,6 +285,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw;
             }
         }
+
+        public override string GetFilenamePart(string fileName)
+        {
+            if (fileName.IndexOf(@"/") != -1)
+            {
+                var parts = fileName.Split(new[] { @"/" }, StringSplitOptions.RemoveEmptyEntries);
+                return parts.LastOrDefault();
+            }
+            else
+            {
+                return fileName;
+            }
+        }
+
         #endregion
 
         #region Private methods
@@ -328,5 +343,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             }
         }
         #endregion
+
+      
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileConnectorBase.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileConnectorBase.cs
@@ -100,6 +100,11 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         /// <param name="container">Name of the container to delete the file from</param>
         public abstract void DeleteFile(string fileName, string container);
 
+        /// <summary>
+        /// Returns a filename without a path
+        /// </summary>
+        /// <param name="fileName">Path to the file to retrieve the filename from</param>
+        public abstract string GetFilenamePart(string fileName);
         #endregion
 
         #region Helper methods

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/FileSystemConnector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using OfficeDevPnP.Core.Utilities;
 
@@ -87,6 +88,19 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
         public override string GetFile(string fileName)
         {
             return GetFile(fileName, GetContainer());
+        }
+
+        public override string GetFilenamePart(string fileName)
+        {
+            if (fileName.IndexOf(@"\") != -1)
+            {
+                var parts = fileName.Split(new []{@"\"}, StringSplitOptions.RemoveEmptyEntries);
+                return parts.LastOrDefault();
+            }
+            else
+            {
+                return fileName;
+            }
         }
 
         /// <summary>

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.SharePoint.Client;
 using OfficeDevPnP.Core.Utilities;
@@ -321,6 +322,20 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
                 throw;
             }
         }
+
+        public override string GetFilenamePart(string fileName)
+        {
+            if (fileName.IndexOf(@"/") != -1)
+            {
+                var parts = fileName.Split(new[] { @"/" }, StringSplitOptions.RemoveEmptyEntries);
+                return parts.LastOrDefault();
+            }
+            else
+            {
+                return fileName;
+            }
+        }
+
         #endregion
 
         #region Private Methods
@@ -441,5 +456,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.Connectors
             }
         }
         #endregion
+
+      
     }
 }

--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -42,7 +42,8 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                 var folder = web.EnsureFolderPath(folderName);
 
-                Microsoft.SharePoint.Client.File targetFile = null;
+                File targetFile = null;
+
                 var checkedOut = false;
 
                 targetFile = folder.GetFile(file.Src);
@@ -55,7 +56,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
                         using (var stream = template.Connector.GetFileStream(file.Src))
                         {
-                            targetFile = folder.UploadFile(file.Src, stream, file.Overwrite);
+                            targetFile = folder.UploadFile(template.Connector.GetFilenamePart(file.Src), stream, file.Overwrite);
                         }
                     }
                     else
@@ -67,7 +68,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
                 {
                     using (var stream = template.Connector.GetFileStream(file.Src))
                     {
-                        targetFile = folder.UploadFile(file.Src, stream, file.Overwrite);
+                        targetFile = folder.UploadFile(template.Connector.GetFilenamePart(file.Src), stream, file.Overwrite);
                     }
 
                     checkedOut = CheckOutIfNeeded(web, targetFile);

--- a/Solutions/PowerShell.Commands/Setup/Product.wxs
+++ b/Solutions/PowerShell.Commands/Setup/Product.wxs
@@ -27,6 +27,8 @@
 
     <Feature Id="ProductFeature" Title="OfficeDev PnP PowerShell Commands" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="ENVIRONMENTVARS" />
+
     </Feature>
 
     <PropertyRef Id="NETFRAMEWORK45"/>
@@ -93,7 +95,17 @@
         <File Id="OfficeSDK.Client.Policy" Source="$(var.OfficeDevPnP.PowerShell.Commands.ProjectDir)bin\$(var.OfficeDevPnP.PowerShell.Commands.Configuration)\Microsoft.Office.Client.Policy.dll" />
         <File Id="OfficeSDK.Client.TranslationServices" Source="$(var.OfficeDevPnP.PowerShell.Commands.ProjectDir)bin\$(var.OfficeDevPnP.PowerShell.Commands.Configuration)\Microsoft.Office.Client.TranslationServices.dll" />
         <File Id="NewtonSoft" Source="$(var.OfficeDevPnP.Core.ProjectDir)bin\$(var.OfficeDevPnP.Core.Configuration)\Newtonsoft.Json.Dll" />
-        <Environment Id="PSMODULEPATH" Name="PSMODULEPATH" Value="[APPFOLDER]" Permanent="no" Part="last" Action="set" System="no" />
+        <!-- <Environment Id="PSMODULEPATH" Name="PSMODULEPATH" Value="[APPFOLDER]" Permanent="no" Part="last" Action="set" System="no" /> -->
+      </Component>
+    </ComponentGroup>
+    <ComponentGroup Id="ENVIRONMENTVARS" Directory="TARGETDIR">
+      <Component Id="EnvironmentVarPerMachine" Guid="{4D971CA5-CFE1-4121-B265-7C56B75D12A1}">
+        <Condition>ALLUSERS=1  OR (ALLUSERS=2 AND Privileged)</Condition>
+        <Environment Id="PSMODULEPATHPERMACHINE" Name="PSMODULEPATH" Value="[APPFOLDER]" Permanent="no" Part="last" Action="set" System="yes" />
+      </Component>
+      <Component Id="EnvironmentVarPerUser" Guid="{CAE7B727-018A-4F37-9D62-C70363B9A9D1}">
+        <Condition>ALLUSERS="" OR (ALLUSERS=2 AND (NOT Privileged))</Condition>
+        <Environment Id="PSMODULEPATHPERUSER" Name="PSMODULEPATH" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName]" Permanent="no" Part="last" Action="set" System="no" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/Solutions/PowerShell.Commands/Setup/Product.wxs
+++ b/Solutions/PowerShell.Commands/Setup/Product.wxs
@@ -10,19 +10,31 @@
      xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
      >
-  <Product Id="*" Name="$(var.ProductName)" Language="1033" Version="1.2.0.0" Manufacturer="OfficeDev PnP" UpgradeCode="630fe2af-dc42-467d-94c8-6eefd065cbfa">
-    <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
-    <Property Id="MSIUSEREALADMINDETECTION" Value="1" />
+  <Product Id="*"
+           Name="$(var.ProductName)"
+           Language="1033"
+           Version="1.2.0.0"
+           Manufacturer="OfficeDev PnP"
+           UpgradeCode="630fe2af-dc42-467d-94c8-6eefd065cbfa">
+
+    <Package InstallerVersion="200"
+             Compressed="yes"  />
+    <!--<Property Id="MSIUSEREALADMINDETECTION" Value="1" />-->
+
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
     <MediaTemplate  EmbedCab="yes" />
 
     <Feature Id="ProductFeature" Title="OfficeDev PnP PowerShell Commands" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
     </Feature>
+
     <PropertyRef Id="NETFRAMEWORK45"/>
+
     <Condition Message="This application requires .NET Framework 4.0. Please install the .NET Framework then run this installer again.">
       <![CDATA[Installed OR NETFRAMEWORK45]]>
     </Condition>
+
     <Property Id="POWERSHELLCOMPATIBLE">
       <RegistrySearch Id="PSCompatible"
                       Root="HKLM"
@@ -35,29 +47,32 @@
       <![CDATA[Installed OR (POWERSHELLCOMPATIBLE >< "3.0")]]>
     </Condition>
   </Product>
+
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder">
         <Directory Id="APPFOLDER" Name="OfficeDevPnP">
           <Directory Id="PowerShell" Name="PowerShell">
             <Directory Id="Modules" Name="Modules">
-              <Directory Id="INSTALLFOLDER" Name="OfficeDevPnP.PowerShell.Commands" />
+              <Directory Id="APPLICATIONFOLDER" Name="OfficeDevPnP.PowerShell.Commands" />
             </Directory>
           </Directory>
         </Directory>
       </Directory>
     </Directory>
 
-    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
     <WixVariable Id="WixUILicenseRtf" Value="Apache License Version 2.rtf" />
     <WixVariable Id="WixUIDialogBmp" Value="officedevpnp.bmp"/>
     <WixVariable Id="WixUIBannerBmp" Value="setupbanner.png"/>
-    <UIRef Id="WixUI_Minimal" />
+
+    <Property Id="ApplicationFolderName" Value="OfficeDevPnP.PowerShell.Commands" />
+    <Property Id="WixAppFolder" Value="WixPerMachineFolder" />
+    <UIRef Id="WixUI_Advanced" />
 
   </Fragment>
 
   <Fragment>
-    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+    <ComponentGroup Id="ProductComponents" Directory="APPLICATIONFOLDER">
       <Component Id="PowerShellCommands" Guid="{1F5CA574-E185-49D2-9A91-CD46A8548D3E}">
         <File Id="Commands" Source="$(var.OfficeDevPnP.PowerShell.Commands.TargetPath)" />
         <File Id="CommandsHelp" Source="$(var.OfficeDevPnP.PowerShell.Commands.TargetPath)-help.xml"/>
@@ -78,7 +93,7 @@
         <File Id="OfficeSDK.Client.Policy" Source="$(var.OfficeDevPnP.PowerShell.Commands.ProjectDir)bin\$(var.OfficeDevPnP.PowerShell.Commands.Configuration)\Microsoft.Office.Client.Policy.dll" />
         <File Id="OfficeSDK.Client.TranslationServices" Source="$(var.OfficeDevPnP.PowerShell.Commands.ProjectDir)bin\$(var.OfficeDevPnP.PowerShell.Commands.Configuration)\Microsoft.Office.Client.TranslationServices.dll" />
         <File Id="NewtonSoft" Source="$(var.OfficeDevPnP.Core.ProjectDir)bin\$(var.OfficeDevPnP.Core.Configuration)\Newtonsoft.Json.Dll" />
-        <Environment Id="PSMODULEPATH" Name="PSMODULEPATH" Value="[APPFOLDER]" Permanent="no" Part="last" Action="set" System="yes" />
+        <Environment Id="PSMODULEPATH" Name="PSMODULEPATH" Value="[APPFOLDER]" Permanent="no" Part="last" Action="set" System="no" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
By clicking on 'advanced' one can now pick if the installation should be done for the current user only, or for all users.

If current user is picked, the installation will be done to [userhomefolder]\AppData\Local\Apps\OfficeDevPnP.PowerShell.Commands, otherwise the installation will be done to [programfilesfolder]\OfficeDevPnP\PowerShell\Modules\OfficeDevPnP.PowerShell.Commands.

The PSModulePath will be set accordingly.