### PR TITLE
Skip token replacement in Field Objecthandler

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -42,7 +42,7 @@ namespace OfficeDevPnP.Core.Framework.Provisioning.ObjectHandlers
 
             foreach (var field in fields)
             {
-                XElement templateFieldElement = XElement.Parse(field.SchemaXml.ToParsedString());
+                XElement templateFieldElement = XElement.Parse(field.SchemaXml.ToParsedString("~sitecollection"));
                 var fieldId = templateFieldElement.Attribute("ID").Value;
 
                 if (!existingFieldIds.Contains(Guid.Parse(fieldId)))


### PR DESCRIPTION
When provisioning SiteColumns we need to skip replacement of ~sitecollection token because the field can contain a JSLink with the token.