### PR TITLE
Fix: Set search scope to SPSite and not SPWeb when importing search c…

### DIFF
--- a/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/SearchExtensions.cs
+++ b/OfficeDevPnP.Core/OfficeDevPnP.Core/AppModelExtensions/SearchExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.SharePoint.Client
         /// <param name="searchConfiguration"></param>
         public static void SetSearchConfiguration(this Site site, string searchConfiguration)
         {
-            SetSearchConfigurationImplementation(site.Context, SearchObjectLevel.SPWeb, searchConfiguration);
+            SetSearchConfigurationImplementation(site.Context, SearchObjectLevel.SPSite, searchConfiguration);
         }
 
 


### PR DESCRIPTION
When importing search configuration xml on a Site it should be imported as the SPSite scope not SPWeb. The Get config method already has SPSite when export from a Site object.