### PR TITLE
Allow remove user when 'AllowDuplicate' is enabled

### DIFF
--- a/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/peoplepickercontrol.js
+++ b/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/peoplepickercontrol.js
@@ -197,10 +197,17 @@
         // Remove resolved user from the array and updates the hidden field control with a JSON string
         PeoplePicker.prototype.RemoveResolvedUser = function (lookupValue) {
             var newResolvedUsers = [];
+            var userRemoved = false;
+            
             for (var i = 0; i < this._ResolvedUsers.length; i++) {
                 var resolvedLookupValue = this._ResolvedUsers[i].Login ? this._ResolvedUsers[i].Login : this._ResolvedUsers[i].LookupId;
-                if (resolvedLookupValue != lookupValue) {
+                if (resolvedLookupValue != lookupValue || userRemoved == true) {
                     newResolvedUsers.push(this._ResolvedUsers[i]);
+                }
+                
+                // Handle duplicates if enabled, only remove one user
+                if(resolvedLookupValue == lookupValue){
+                    userRemoved = true;
                 }
             }
             this._ResolvedUsers = newResolvedUsers;


### PR DESCRIPTION
If 'AllowDuplicates' is enabled and a user clicks on the 'x' near a duplicate entry's name, all instances of that entry are removed.