### PR TITLE
Display login name with email in people picker

### DIFF
--- a/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/csompeoplepickercontrol.js
+++ b/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/csompeoplepickercontrol.js
@@ -280,11 +280,17 @@
                         var displayName = item['DisplayText'];
                         var title = item['EntityData']['Title'];
                         var email = item['EntityData']['Email'];
-                        txtResults += this.Format(displayTemplate, this.InstanceName, loginName, this.HtmlEncode(displayName), email, displayName, loginName.split('|')[2], title);
+                        
+                        var loginNameDisplay = email;
+                            if (loginName && loginName.indexOf('|') > -1) {
+                                var segs = loginName.split('|');
+                                loginNameDisplay = loginNameDisplay + " " + segs[segs.length - 1];
+                                loginNameDisplay = loginNameDisplay.trim();
+                            }
+                        txtResults += this.Format(displayTemplate, this.InstanceName, loginName, this.HtmlEncode(displayName), email, displayName, loginNameDisplay, title);
                     }
                     var resultDisplay = '';
                     txtResults += '<div class=\'ms-emphasisBorder\' style=\'width: 400px; padding: 4px; border-left: none; border-bottom: none; border-right: none; cursor: default;\'>';
-                    if (results.length == 1) {
                         resultDisplay = 'Showing {0} result';
                         if (typeof resultsSingle != 'undefined') {
                             resultDisplay = resultsSingle;


### PR DESCRIPTION
Currently loginName.split('|')[2] not display expected result so added loginNameDisplay as implemented in peoplepickercontrol.js