### PR TITLE
Taxonomypicker - support for term suggestions based on containing

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -164,13 +164,19 @@
             return termList;
         },
         //get suggestions based on the values typed by user
-        getSuggestions: function (text, useContainsSuggestions) {
+        getSuggestions: function (text) {
             var matches = new Array();
             $(this.FlatTermsForSuggestions).each(function (i, e) {
-                if (useContainsSuggestions && e.Name.toLowerCase().indexOf(text.toLowerCase()) >= 0) {
+                if (e.Name.toLowerCase().indexOf(text.toLowerCase()) == 0) {
                     matches.push(e);
                 }
-                else if (!useContainsSuggestions && e.Name.toLowerCase().indexOf(text.toLowerCase()) == 0) {
+            });
+            return matches;
+        },
+        getContainsSuggestions: function (text, useContainsSuggestions) {
+            var matches = new Array();
+            $(this.FlatTermsForSuggestions).each(function (i, e) {
+                if (e.Name.toLowerCase().indexOf(text.toLowerCase()) >= 0) {
                     matches.push(e);
                 }
             });
@@ -677,7 +683,7 @@
 
                 if (txt.length > 0) {
                     //look for all matching suggestions
-                    var suggestions = this.TermSet.getSuggestions(txt, this._useContainsSuggestions);
+                    var suggestions = this._useContainsSuggestions ? this.TermSet.getContainsSuggestions(txt) : this.TermSet.getSuggestions(txt);
 
                     //trim suggestions based on what is already in this._selectedTerms
                     suggestions = this.trimSuggestions(suggestions);


### PR DESCRIPTION
Added support for something that people have been asking me for when using SharePoints own taxonomypicker - being able to find things on terms not only starting by, but also containing. The problem is that users don't always know exactly the term they are looking for and sometimes have a  hard time finding the correct term. This can result in "duplicate" terms because users create new ones instead of using the existing ones.
Thanks @pbjorklund for fixing my git issues!

![fuzzy-highligt](https://cloud.githubusercontent.com/assets/8503139/10546835/c8814a44-7430-11e5-8d99-18a3f540eeb8.PNG)
![standard](https://cloud.githubusercontent.com/assets/8503139/10546840/d7c1995a-7430-11e5-9557-14625092f3b6.PNG)

