### PR TITLE
jQuery People Picker: Make search work in all browsers

### DIFF
--- a/Components/Core.JQuery/Core.JQueryWeb/Scripts/PnP/sp.peoplepicker.js
+++ b/Components/Core.JQuery/Core.JQueryWeb/Scripts/PnP/sp.peoplepicker.js
@@ -108,7 +108,7 @@
                 var controlContext = methods.getControlContext(source);
 
                 // we add on the key that was just pressed
-                var currentValue = controlContext.userEditInput.val() + e.key;
+                var currentValue = controlContext.userEditInput.val() + String.fromCharCode(e.which);
 
                 if (currentValue == null || currentValue.length < settings.minSearchTriggerLength) {
                     // do nothing. seriously, stop doing things if they haven't entered enough letters


### PR DESCRIPTION
Sometimes e.key can be undefined, which results in a currentValue containing the string `undefined`. For jQuery events `e.which` should always be set and can be converted using `String.fromCharCode`.