### PR TITLE
Added support for locals, simplified update group code

### DIFF
--- a/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
+++ b/Samples/Core.AppScriptPart/Core.AppScriptPartWeb/Pages/Default.aspx.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using Microsoft.SharePoint.Client.WebParts;
+using ListItem = Microsoft.SharePoint.Client.ListItem;
 
 namespace Core.AppScriptPartWeb
 {
@@ -58,7 +60,13 @@ namespace Core.AppScriptPartWeb
             var spContext = SharePointContextProvider.Current.GetSharePointContext(Context);
             using (var clientContext = spContext.CreateUserClientContextForSPHost())
             {
-                var folder = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery").RootFolder;
+                Site site = clientContext.Site;
+                clientContext.Load(site, s => s.Url);
+                clientContext.ExecuteQuery();
+                String webPartGalleryUrl = site.Url.TrimEnd('/') + "/_catalogs/wp";
+
+                var folder = site.RootWeb.GetList(webPartGalleryUrl).RootFolder;
+                //var folder = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery").RootFolder;
                 clientContext.Load(folder);
                 clientContext.ExecuteQuery();
 
@@ -71,24 +79,11 @@ namespace Core.AppScriptPartWeb
                     fileInfo.Overwrite = true;
                     fileInfo.Url = "userprofileinformation.webpart";
                     File file = folder.Files.Add(fileInfo);
+                    // Let's update the group for just uploaded web part
+                    ListItem webpartItem = file.ListItemAllFields;
+                    webpartItem["Group"] = "Add-in Script Part";
+                    webpartItem.Update();
                     clientContext.ExecuteQuery();
-                }
-
-                // Let's update the group for just uploaded web part
-                var list = clientContext.Site.RootWeb.Lists.GetByTitle("Web Part Gallery");
-                CamlQuery camlQuery = CamlQuery.CreateAllItemsQuery(100);
-                Microsoft.SharePoint.Client.ListItemCollection items = list.GetItems(camlQuery);
-                clientContext.Load(items);
-                clientContext.ExecuteQuery();
-                foreach (var item in items)
-                {
-                    // Just random group name to differentiate it from the rest
-                    if (item["FileLeafRef"].ToString().ToLowerInvariant() == "userprofileinformation.webpart")
-                    {
-                        item["Group"] = "Add-in Script Part";
-                        item.Update();
-                        clientContext.ExecuteQuery();
-                    }
                 }
 
                 lblStatus.Text = string.Format("Add-in script part has been added to web part gallery. You can find 'User Profile Information' script part under 'Add-in Script Part' group in the <a href='{0}'>host web</a>.", spContext.SPHostUrl.ToString());


### PR DESCRIPTION
Replaced the line clientContext.Site.RootWeb.Lists.GetByTitle to get list by Url so that it will work in none English environments.
Updated the item returned by the file rather than using CAML on the list.