### PR TITLE
Allow to set this in jQuery promises

### DIFF
--- a/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
+++ b/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
@@ -1,26 +1,26 @@
 ﻿$pnpcore.onStart(function () {
-
+    
     $('#runtest').on('click', function (e) {
-
+        
         // stop normal button stuff
         e.preventDefault();
 
         // base example
         $pnpcore.withSPContext(function (context) {
-
+            
             var web = context.get_web();
             context.load(web);
 
-            context.ext_executeQueryRetry().done(function () {
-
-                $('#result').html('Successfully loaded web! Web Title: ' + web.get_title());
+            context.ext_executeQueryRetry(web).done(function () {
+                
+                $('#result').html('Successfully loaded web! Web Title: ' + this.get_title());
                 $('#result').css({ color: 'green' });
-
+                
             }).fail(function (sender, args) {
-
+                
                 $('#result').html('Error loading web: ' + args.get_message());
                 $('#result').css({ color: 'red' });
-
+                
             });
         });
     });

--- a/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
+++ b/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
@@ -1,26 +1,19 @@
-﻿$pnpcore.onStart(function () {
-    
-    $('#runtest').on('click', function (e) {
-        
+﻿$pnpcore.onStart(function () {    
+    $('#runtest').on('click', function (e) {        
         // stop normal button stuff
         e.preventDefault();
 
         // base example
-        $pnpcore.withSPContext(function (context) {
-            
+        $pnpcore.withSPContext(function (context) {            
             var web = context.get_web();
             context.load(web);
 
-            context.executeQueryRetry(web).done(function () {
-                
+            context.executeQueryRetry(web).done(function () {               
                 $('#result').html('Successfully loaded web! Web Title: ' + this.get_title());
-                $('#result').css({ color: 'green' });
-                
-            }).fail(function (sender, args) {
-                
+                $('#result').css({ color: 'green' });                
+            }).fail(function (sender, args) {                
                 $('#result').html('Error loading web: ' + args.get_message());
-                $('#result').css({ color: 'red' });
-                
+                $('#result').css({ color: 'red' });                
             });
         });
     });

--- a/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
+++ b/Components/Core.JQuery/Core.JQuery.Promises/Scripts/AddIn.js
@@ -11,7 +11,7 @@
             var web = context.get_web();
             context.load(web);
 
-            context.ext_executeQueryRetry(web).done(function () {
+            context.executeQueryRetry(web).done(function () {
                 
                 $('#result').html('Successfully loaded web! Web Title: ' + this.get_title());
                 $('#result').css({ color: 'green' });

--- a/Components/Core.JQuery/Core.JQuery.Promises/Scripts/officepnp.js
+++ b/Components/Core.JQuery/Core.JQuery.Promises/Scripts/officepnp.js
@@ -99,7 +99,7 @@
              * @param {object} context - Context passed to the doneCallbacks as the this object.
              * @returns {jquery.promise} Promise for the request.
              */
-            ext_executeQueryPromise: function (context) {                
+            executeQueryPromise: function (context) {                
                 var self = this, // Maintain self-awareness.
                     def = $.Deferred(); // Create a deferred.
 
@@ -125,7 +125,7 @@
              * @param {object} context - Context passed to the doneCallbacks as the this object.
              * @returns {jquery.promise} Promise for the request.
              */
-            ext_executeQueryRetry: function (context) {
+            executeQueryRetry: function (context) {
                 var self = this, // Maintain self-awareness.
                     def = $.Deferred(), // Create a deferred.
                     // Create a context to track our async retries.

--- a/Components/Core.JQuery/Core.JQuery.Promises/Scripts/officepnp.js
+++ b/Components/Core.JQuery/Core.JQuery.Promises/Scripts/officepnp.js
@@ -1,5 +1,4 @@
 ﻿var $pnpcore = {
-
     onStartPromise: null,
     getContextPromise: null,
     spContext: null,
@@ -18,12 +17,10 @@
     // a custom onStart method to ensure anything we need in our Add-In is ready
     // includes the full DOM load as resolved by $(function() {...}) syntax
     onStart: function (/*function()*/ onStartFunc) {
-
         var hostUrl = $pnpcore.getHostWebUrl();
         var scriptbase = hostUrl + $pnpcore.scriptbasepath;
 
         if ($pnpcore.onStartPromise === null) {
-
             // these scripts will be loaded ahead of other files and scripts
             var fileUrls = ['SP.Runtime.js', 'SP.js', 'SP.RequestExecutor.js'].select(function (s) {
                 return scriptbase + s;
@@ -49,14 +46,10 @@
     // provides an easy way to use a client context from a centralized location
     // also ensures one context is created for all functions in your Add-In
     withSPContext: function (/*function(context)*/ action) {
-        
         if ($pnpcore.getContextPromise === null) {
-            
             $pnpcore.getContextPromise = $.Deferred(function (def) {
-                
                 // use custom onstart to ensure we have the files loaded and are ready to do stuff
-                $pnpcore.onStart(function () {
-                    
+                $pnpcore.onStart(function () {                    
                     try {
                         
                         var addinWebUrl = $pnpcore.getAddInWebUrl();
@@ -70,8 +63,7 @@
                         // if we have a problem just reject with the associated error
                         def.rejectWith(e, [e]);
                     }
-                });
-                
+                });                
             }).promise();
         }
 
@@ -91,9 +83,7 @@
     // the benefit of this approach is that you can call it at any time to ensure the extended functionality is present
     // another option would be to pass a ClientContext instance to this method instead of extending prototype directly
     extendSPClientContext: function () {
-
         $.extend(SP.ClientContext.prototype, {
-
             /**
              * Executes the current pending request asynchronously on the server using a jQuery promise.
              * @param {object} context - Context passed to the doneCallbacks as the this object.
@@ -224,7 +214,6 @@
 
     // loads a set of specificed files, returning a promise
     loadFiles: function (/*string[]*/ files) {
-
         // create a promise
         var promise = $.Deferred();
 
@@ -240,13 +229,9 @@
         }
 
         // this function will be used to recursively load all the files
-        var engine = function () {
-
-            // maintain context
-            var self = this;
-
-            // get the next file to load
-            var file = self.files.shift();
+        var engine = function () {            
+            var self = this, // Maintain context.
+                file = self.files.shift(); // get the next file to load.
 
             // load the remote script file
             $.getScript(file).done(function () {
@@ -304,7 +289,6 @@
 
     // appends the required SP parameters to the supplied url, great for web api calls to maintain context on the server side
     appendSPQueryToUrl: function (/*string*/ url) {
-
         // we already have the SPHostUrl param, just give back the url
         if (url.indexOf('SPHostUrl=') > -1) {
             return url;
@@ -336,7 +320,6 @@
 
     // ensures that all the appropriate links in the page have the SP parameters attached
     ensureContextQueryString: function () {
-
         // remove the redirect flag
         var SPHasRedirectedToSharePointParam = "&SPHasRedirectedToSharePoint=1";
         var queryString = window.location.search;
@@ -349,7 +332,6 @@
 
     // process all the supplied tags
     ensureSPHostUrlInLinks: function (/*jquery*/ parentNode) {
-
         var currentAuthority = $pnpcore.getAuthorityFromUrl(window.location.href);
 
         parentNode.filter(function () {

--- a/Components/Core.JQuery/promises.md
+++ b/Components/Core.JQuery/promises.md
@@ -43,6 +43,6 @@ In the samples you will see that SP.ClientContext.prototype has been extended di
 
 ### Query with Retry ###
 
-If you have used the PnP CSOM framework before you are familiar with the [ExecuteQueryRetry](https://github.com/OfficeDev/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/AppModelExtensions/ClientContextExtensions.cs) method. The question has been asked if a similar capability is available in the JSOM framework. As an exercise, this is possible and you can see the method ext_executeQueryRetry in the [officepnp.js](Core.JQuery.Promises/Scripts/officepnp.js) file.
+If you have used the PnP CSOM framework before you are familiar with the [ExecuteQueryRetry](https://github.com/OfficeDev/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/AppModelExtensions/ClientContextExtensions.cs) method. The question has been asked if a similar capability is available in the JSOM framework. As an exercise, this is possible and you can see the method `executeQueryRetry` in the [officepnp.js](Core.JQuery.Promises/Scripts/officepnp.js) file.
 
 **An IMPORTANT note...depending on the error all the pending actions in the ClientContext may be flushed and a retry may not be possible. This will result in a failure followed by a success produced by an empty query.**


### PR DESCRIPTION
This PR allows to set the context passed to the doneCallbacks as the this object to executeQueryPromise and executeQueryRetry. Also removes the possibility to pass Done and Fail callbacks since they can be called on the returned promise and does some general cleanup.