### PR TITLE
PeoplePicker error handling

### DIFF
--- a/Components/Core.JQuery/Core.JQueryWeb/Scripts/PnP/sp.peoplepicker.js
+++ b/Components/Core.JQuery/Core.JQueryWeb/Scripts/PnP/sp.peoplepicker.js
@@ -142,6 +142,9 @@
 
                     // issue request
                     spContext.executeQueryAsync($app.getCtxCallback(searchCtx, methods.searchSuccess), $app.getCtxCallback(searchCtx, methods.searchFail));
+                }).fail(function () {
+                    controlContext.dropdown.empty();
+                    alert('There was a problem connecting to SharePoint. Please refresh the page to try again.');
                 });
             },
 


### PR DESCRIPTION
Add error handling to the people picker and notify the user in case the SharePoint context could not be created.