### PR TITLE
Adding custom.spcolor to deployed files.  Without this file the tool …

### DIFF
--- a/Solutions/Provisioning.Framework.Cloud.Async/Provisioning.Framework.Cloud.Async.Job/Provisioning.Framework.Cloud.Async.Job.csproj
+++ b/Solutions/Provisioning.Framework.Cloud.Async/Provisioning.Framework.Cloud.Async.Job/Provisioning.Framework.Cloud.Async.Job.csproj
@@ -167,9 +167,9 @@
     <None Include="packages.config" />
     <None Include="Properties\PublishProfiles\vesaj-pnpenginejob.pubxml" />
     <None Include="Properties\webjob-publish-settings.json" />
-    <None Include="Resources\custom.spcolor">
+    <Content Include="Resources\custom.spcolor">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Provisioning.Framework.Cloud.Async.Common\Provisioning.Framework.Cloud.Async.Common.csproj">


### PR DESCRIPTION
…throws an exception

The solution out-of-box will throw an exception when attempting to perform site collection creation via a baked-in template because the system cannot find custom.spcolor.

Adding "content" metadata to this file causes it to be properly deployed to azure using Visual Studio publishing