### PR TITLE
Fixed possible encoding issues when search term contains special characters

### DIFF
--- a/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/peoplepickercontrol.js
+++ b/Components/Core.PeoplePicker/Core.PeoplePickerWeb/Scripts/peoplepickercontrol.js
@@ -474,7 +474,7 @@
                                 //make call to method in code-behind
                                 $.ajax({
                                     type: "POST",
-                                    url: parent.GetServerDataMethod() + "?SearchString=" + searchText + "&SPHostUrl=" + parent.GetSpHostUrl() + "&PrincipalType=" + parent.GetPrincipalType() + (spGroupName ? "&SPGroupName=" + spGroupName : ""),
+                                    url: parent.GetServerDataMethod() + "?SearchString=" + encodeURIComponent(searchText) + "&SPHostUrl=" + parent.GetSpHostUrl() + "&PrincipalType=" + parent.GetPrincipalType() + (spGroupName ? "&SPGroupName=" + spGroupName : ""),
                                     data: "{}",
                                     contentType: "application/json; charset=utf-8",
                                     dataType: "json",


### PR DESCRIPTION
The search term was directly included in the URL which results in encoding issues on server side when the request was sent by Internet Explorer and umlauts has been contained in the search term.
By using encodeURIComponent all special characters are encoded before performing the request.