### PR TITLE
Made a minor change in the GetUsersFromActiveDirectory method. Added …

### DIFF
--- a/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/Program.cs
+++ b/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/Program.cs
@@ -76,7 +76,7 @@ namespace Core.UserProfiles.Sync
                     pagedCollection = await pagedCollection.GetNextPageAsync();
                     //Below condition checks for the last batch of users and adds it to the list. 
                     //Otherwise, the pagedCollection.MorePagesAvailable fails in the while condition and the loop misses the last batch of users.
-                    if (pagedCollection != null)
+                    if (!pagedCollection.MorePagesAvailable)
                     {
                         usersList.AddRange(pagedCollection.CurrentPage.ToList());
                     }

--- a/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/Program.cs
+++ b/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/Program.cs
@@ -74,7 +74,12 @@ namespace Core.UserProfiles.Sync
                 {
                     usersList.AddRange(pagedCollection.CurrentPage.ToList());
                     pagedCollection = await pagedCollection.GetNextPageAsync();
-
+                    //Below condition checks for the last batch of users and adds it to the list. 
+                    //Otherwise, the pagedCollection.MorePagesAvailable fails in the while condition and the loop misses the last batch of users.
+                    if (pagedCollection != null)
+                    {
+                        usersList.AddRange(pagedCollection.CurrentPage.ToList());
+                    }
                 } while (pagedCollection != null && pagedCollection.MorePagesAvailable);
             }
             


### PR DESCRIPTION
Made a minor change in the GetUsersFromActiveDirectory method. Added comment on the change within the code. The do-while loop incorrectly misses the last batch of users. The condition I added checks for the last batch of users and adds it to the list. Otherwise, the pagedCollection.MorePagesAvailable fails in the while condition and the loop misses the last batch of users.