### PR TITLE
Updated taxonomypickercontrol.js and readme.md

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -755,8 +755,15 @@
                                 itemHtml.click(Function.createDelegate(this, this.suggestionClicked));
                             }
                         }));
+                        this._suggestionContainer.show();
                     }
-                    this._suggestionContainer.show();
+                    else {
+                        this._suggestionContainer.hide();
+                    }
+                    
+                }
+                else {
+                    this._suggestionContainer.hide();
                 }
             }
             else

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -15,7 +15,7 @@
             this.RawTerm = rawTerm;
         }
     }
-    $.extend(Term.prototype, {
+    jQuery.extend(Term.prototype, {
         //creates a cloned copy of a term to avoid reference issues
         clone: function () {
             return new Term(this.RawTerm);
@@ -23,7 +23,7 @@
         //converts a term to an html tree node
         toHtmlLabel: function () {
             var addlClass = (this.Children.length > 0) ? 'collapsed' : '';
-            return $('<li class="cam-taxpicker-treenode-li"><div class="cam-taxpicker-treenode"><div class="cam-taxpicker-expander ' + addlClass + '"></div><img src="../styles/images/EMMTerm.png" alt=""/><span class="cam-taxpicker-treenode-title"  data-item="' + this.Name + '|' + this.Id + '">' + this.Name + '</span></div></li>');
+            return jQuery('<li class="cam-taxpicker-treenode-li"><div class="cam-taxpicker-treenode"><div class="cam-taxpicker-expander ' + addlClass + '"></div><img src="../styles/images/EMMTerm.png" alt=""/><span class="cam-taxpicker-treenode-title"  data-item="' + this.Name + '|' + this.Id + '">' + this.Name + '</span></div></li>');
         }
     });
     //********************** END Term Class **********************
@@ -51,7 +51,7 @@
         this.LevelToShowTerms = options.levelToShowTerms; // show terms only till the specified level
         this.UseTermSetasRootNode = options.useTermSetasRootNode //bool indicating if termset to be shown as root node or not
     }
-    $.extend(TermSet.prototype, {
+    jQuery.extend(TermSet.prototype, {
         //initializes the Termset, including loading all terms using CSOM
         initialize: function () {
             //Get the taxonomy session using CSOM
@@ -166,7 +166,7 @@
         //get suggestions based on the values typed by user
         getSuggestions: function (text) {
             var matches = new Array();
-            $(this.FlatTermsForSuggestions).each(function (i, e) {
+            jQuery(this.FlatTermsForSuggestions).each(function (i, e) {
                 if (e.Name.toLowerCase().indexOf(text.toLowerCase()) == 0) {
                     matches.push(e);
                 }
@@ -175,7 +175,7 @@
         },
         getContainsSuggestions: function (text, useContainsSuggestions) {
             var matches = new Array();
-            $(this.FlatTermsForSuggestions).each(function (i, e) {
+            jQuery(this.FlatTermsForSuggestions).each(function (i, e) {
                 if (e.Name.toLowerCase().indexOf(text.toLowerCase()) >= 0) {
                     matches.push(e);
                 }
@@ -265,6 +265,7 @@
         this._isMulti = options.isMulti; //specifies if the user can select multiple terms
         this._isReadOnly = options.isReadOnly; //specifies whether the control is used for display purposes 
         this._allowFillIn = options.allowFillIn; //specifies if the user can add new terms (only applies to Open Termsets)
+        this._enterFillIn = options.enterFillIn; //specifies if the user can add new terms just click on enter (not taxonomy picker dialog needed)
         this._termSetId = options.termSetId; //the termset id to bind the control to
         this._useHashtags = options.useHashtags; //indicates that the hashtags termset should be used tp bind the control
         this._useKeywords = options.useKeywords; //indicates that the keywords termset should be used to bind the control
@@ -297,7 +298,7 @@
         this.initialize();
     }
 
-    $.extend(TaxonomyPicker.prototype, {
+    jQuery.extend(TaxonomyPicker.prototype, {
         //initializes the taxonomy picker
         initialize: function () {
             this.TermSet.initialize(); //initialize the termset to populate available terms
@@ -305,7 +306,7 @@
             //get script path so we can load translation files
             var scriptUrl = '';
             var scriptRevision = '';
-            $('script').each(function (i, el) {
+            jQuery('script').each(function (i, el) {
                 if (el.src.toLowerCase().indexOf('taxonomypickercontrol.js') > -1) {
                     scriptUrl = el.src;
                     scriptRevision = scriptUrl.substring(scriptUrl.indexOf('.js') + 3);
@@ -330,22 +331,24 @@
             }
 
             //create a new wrapper for the control using a div
-            this._control = $('<div class="cam-taxpicker"></div>');
+            this._control = jQuery('<div class="cam-taxpicker"></div>');
 
             //detach the hidden field from the parent and append to the wrapper
             var parent = this._hiddenValidated.parent();
             this._hiddenValidated = this._hiddenValidated.detach();
             parent.append(this._control);
-            this._suggestionContainer = $('<div class="cam-taxpicker-suggestion-container"></div>');
-            this._dlgButton = $('<div class="cam-taxpicker-button"></div>');
+            this._suggestionContainer = jQuery('<div class="cam-taxpicker-suggestion-container"></div>');
+            if (!this._enterFillIn){
+            	this._dlgButton = jQuery('<div class="cam-taxpicker-button"></div>');
+            }
             if (!this._isReadOnly) {
-                this._editor = $('<div class="cam-taxpicker-editor" contenteditable="true"></div>');
+                this._editor = jQuery('<div class="cam-taxpicker-editor" contenteditable="true"></div>');
                 this._control.empty().append(this._editor).append(this._dlgButton).append(this._hiddenValidated);
                 this._control.after(this._suggestionContainer);
             }
             else {
 
-                this._editor = $('<div class="cam-taxpicker-editor-readonly" contenteditable="false"></div>');
+                this._editor = jQuery('<div class="cam-taxpicker-editor-readonly" contenteditable="false"></div>');
                 this._control.empty().append(this._editor).append(this._hiddenValidated);
             }
 
@@ -366,9 +369,11 @@
             }
 
             //wire up control events
-            this._dlgButton.click(Function.createDelegate(this, this.showPickerDialog)); //dialog button is clicked
+            if (!this._enterFillIn){
+            	this._dlgButton.click(Function.createDelegate(this, this.showPickerDialog)); //dialog button is clicked
+            }
             this._editor.keydown(Function.createDelegate(this, this.keydown)); //key is pressed in the editor control
-            $(document).mousedown(Function.createDelegate(this, this.checkExternalClick)); //mousedown somewhere in the document
+            jQuery(document).mousedown(Function.createDelegate(this, this.checkExternalClick)); //mousedown somewhere in the document
         },
         //handle reset
         reset: function () {
@@ -649,8 +654,27 @@
                         this.pushSelectedTerm(matches[0]);
                         html += '<span class="cam-taxpicker-term-selected">' + textValidation.ranges[i].text + '</span>';
                     }
-                    else
-                        html += '<span class="cam-taxpicker-term-invalid">' + textValidation.ranges[i].text + '</span>';
+                    else {
+                    	//
+                    	if (this._enterFillIn){
+                    		//new term
+                    		var termNew = new Term(null);
+                    		var id = newGuid();
+                    		termNew.Id = id;
+                    		termNew.Name =  textValidation.ranges[i].text;
+                       		
+                       		this._selectedTerms.push(termNew);
+                			this._hiddenValidated.val(JSON.stringify(this._selectedTerms));
+                			
+                			this.pushSelectedTerm(termNew);
+
+                    		html += '<span class="cam-taxpicker-term-selected">' + textValidation.ranges[i].text + '</span>';
+                        }
+                        else{
+                        	html += '<span class="cam-taxpicker-term-invalid">' + textValidation.ranges[i].text + '</span>';                  
+                        }
+					}
+
 
                     //check for ambiguous matches
                     if (matches.length > 1) {
@@ -688,9 +712,9 @@
                     //trim suggestions based on what is already in this._selectedTerms
                     suggestions = this.trimSuggestions(suggestions);
 
-                    this._suggestionContainer.empty().append($('<div class="cam-taxpicker-suggestion-title">' + TaxonomyPickerConsts.SUGGESTIONS_HEADER + '</div>'));
+                    this._suggestionContainer.empty().append(jQuery('<div class="cam-taxpicker-suggestion-title">' + TaxonomyPickerConsts.SUGGESTIONS_HEADER + '</div>'));
                     if (suggestions.length > 0) {
-                        $(suggestions).each(Function.createDelegate(this, function (i, e) {
+                        jQuery(suggestions).each(Function.createDelegate(this, function (i, e) {
                             if (i < this._maxSuggestions) {
                                 var startOfMatchIndex = e.Name.toLowerCase().indexOf(txt.toLowerCase());
                                 var match = e.Name.substring(startOfMatchIndex, startOfMatchIndex + txt.length); //get the matched text so we can highlight it
@@ -703,7 +727,7 @@
                                     }
                                 }
                                 var hightlightedText = this._useContainsSuggestions ? getContainsWithHighlightedText(e.Name, match) : getStartingWithHighlightedText(e.Name, match);
-                                var itemHtml = $('<div class="cam-taxpicker-suggestion-item" data-item="' + e.Id + '">' + hightlightedText + ' [' + this.TermSet.Name + ':' + e.PathOfTerm.replace(/;/g, ':') + labelStr + ']</div>');
+                                var itemHtml = jQuery('<div class="cam-taxpicker-suggestion-item" data-item="' + e.Id + '">' + hightlightedText + ' [' + this.TermSet.Name + ':' + e.PathOfTerm.replace(/;/g, ':') + labelStr + ']</div>');
                                 this._suggestionContainer.append(itemHtml);
                                 itemHtml.click(Function.createDelegate(this, this.suggestionClicked));
                             }
@@ -733,16 +757,16 @@
             this.termNodeAddCancel(event);
 
             //set the _dlgCurrTermNode
-            this._dlgCurrTermNode = $(event.target);
+            this._dlgCurrTermNode = jQuery(event.target);
 
             //change the style of the node to selected
-            $('.cam-taxpicker-treenode-title').removeClass('selected');
-            $(event.target).addClass('selected');
+            jQuery('.cam-taxpicker-treenode-title').removeClass('selected');
+            jQuery(event.target).addClass('selected');
 
             //ignore events from root
-            if (!$(event.target).hasClass('root')) {
+            if (!jQuery(event.target).hasClass('root')) {
                 //get the term clicked and set currNode
-                var itemdata = $(event.target).attr('data-item').split('|');
+                var itemdata = jQuery(event.target).attr('data-item').split('|');
                 this._dlgCurrTerm = this.TermSet.getTermById(itemdata[1]);
             }
             else
@@ -754,12 +778,12 @@
             this.termNodeAddCancel(event);
 
             //set the _dlgCurrTermNode
-            this._dlgCurrTermNode = $(event.target);
+            this._dlgCurrTermNode = jQuery(event.target);
 
             //ignore events from root
-            if (!$(event.target).hasClass('root')) {
+            if (!jQuery(event.target).hasClass('root')) {
                 //get the term clicked
-                var itemdata = $(event.target).attr('data-item').split('|');
+                var itemdata = jQuery(event.target).attr('data-item').split('|');
                 term = this.TermSet.getTermById(itemdata[1]);
 
                 //add the term to selected terms array
@@ -800,16 +824,16 @@
         },
         //dialog new term button is clicked
         dialogNewTermClicked: function (event) {
-            if ($('.cam-taxpicker-treenode-newnode').length > 0) // don't allow adding multiple nodes at once
+            if (jQuery('.cam-taxpicker-treenode-newnode').length > 0) // don't allow adding multiple nodes at once
                 return;
 
-            this._dlgNewNodeEditor = $('<div class="cam-taxpicker-treenode-newnode" style="min-width: 100px;" contenteditable="true"></div>');
-            this._dlgNewNode = $('<li class="cam-taxpicker-treenode-li newNode"></li>').append($('<div class="cam-taxpicker-treenode"></div>').append('<div class="cam-taxpicker-expander"></div><img src="../styles/images/EMMTerm.png" alt=""/>').append(this._dlgNewNodeEditor));
+            this._dlgNewNodeEditor = jQuery('<div class="cam-taxpicker-treenode-newnode" style="min-width: 100px;" contenteditable="true"></div>');
+            this._dlgNewNode = jQuery('<li class="cam-taxpicker-treenode-li newNode"></li>').append(jQuery('<div class="cam-taxpicker-treenode"></div>').append('<div class="cam-taxpicker-expander"></div><img src="../styles/images/EMMTerm.png" alt=""/>').append(this._dlgNewNodeEditor));
 
             // only one level allowed for keywords, so always add to the root
             if (this.TermSet.UseKeywords || this._dlgCurrTerm == null) {
-                $('.cam-taxpicker-treenode-title').removeClass('selected');
-                var root = $('.cam-taxpicker-treenode-title.root').first();
+                jQuery('.cam-taxpicker-treenode-title').removeClass('selected');
+                var root = jQuery('.cam-taxpicker-treenode-title.root').first();
                 root.addClass('selected');
                 this._dlgCurrTermNode = root;
                 this._dlgCurrTerm = null;
@@ -818,7 +842,7 @@
             //get the container for the new node
             var ul = this._dlgCurrTermNode.parent().next();
             if (ul.length == 0) { // adding a term to a newly added term
-                ul = $('<ul class="cam-taxpicker-treenode-ul"></ul>').appendTo(this._dlgCurrTermNode.parent().parent());
+                ul = jQuery('<ul class="cam-taxpicker-treenode-ul"></ul>').appendTo(this._dlgCurrTermNode.parent().parent());
             }
             ul.prepend(this._dlgNewNode);
 
@@ -872,7 +896,7 @@
             ul.prepend(newNode);
 
             //change the style to selected and wire events
-            $('.cam-taxpicker-treenode-title').removeClass('selected');
+            jQuery('.cam-taxpicker-treenode-title').removeClass('selected');
             var title = newNode.find('.cam-taxpicker-treenode-title');
             title.addClass('selected');
             title.click(Function.createDelegate(this, this.termNodeClicked));
@@ -895,7 +919,7 @@
         },
         //fires when a user selected a suggested term in the suggestions list
         suggestionClicked: function (event) {
-            var obj = $(event.target);
+            var obj = jQuery(event.target);
             //check sender type...move up to parent if this is a span
             if (obj[0].tagName == 'SPAN')
                 obj = obj.parent();
@@ -918,7 +942,7 @@
         //used to check if focus is lost from the control (invalidate and hide suggestions)
         checkExternalClick: function (event) {
             //check if the target is outside the picker
-            if (!$.contains(this._control[0], event.target) && !$.contains(this._suggestionContainer[0], event.target) && this._dialog != null && !$.contains(this._dialog[0], event.target)) {
+            if (!jQuery.contains(this._control[0], event.target) && !jQuery.contains(this._suggestionContainer[0], event.target) && this._dialog != null && !jQuery.contains(this._dialog[0], event.target)) {
                 var rawText = this._editor.text(); //the raw text in the editor (html stripped out)
                 var textValidation = this.validateText(rawText); //get the text validation
                 var html = this.markInvalidTerms(textValidation); //mark invalid terms
@@ -933,12 +957,12 @@
                 this.TermSet.OnTermsLoaded = Function.createDelegate(this, this.showPickerDialog);
 
                 //add the waiting indicator to the body
-                this._waitingDlg = $('<div class="cam-taxpicker-waiting"><div class="cam-taxpicker-waiting-overlay"></div><div class="cam-taxpicker-waiting-dlg"><div class="cam-taxpicker-waiting-dlg-inner"><img alt="" src="data:image/gif;base64,R0lGODlhEAAQAIAAAFLOQv///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQFCgABACwJAAIAAgACAAACAoRRACH5BAUKAAEALAwABQACAAIAAAIChFEAIfkEBQoAAQAsDAAJAAIAAgAAAgKEUQAh+QQFCgABACwJAAwAAgACAAACAoRRACH5BAUKAAEALAUADAACAAIAAAIChFEAIfkEBQoAAQAsAgAJAAIAAgAAAgKEUQAh+QQFCgABACwCAAUAAgACAAACAoRRACH5BAkKAAEALAIAAgAMAAwAAAINjAFne8kPo5y02ouzLQAh+QQJCgABACwCAAIADAAMAAACF4wBphvID1uCyNEZM7Ov4v1p0hGOZlAAACH5BAkKAAEALAIAAgAMAAwAAAIUjAGmG8gPW4qS2rscRPp1rH3H1BUAIfkECQoAAQAsAgACAAkADAAAAhGMAaaX64peiLJa6rCVFHdQAAAh+QQJCgABACwCAAIABQAMAAACDYwBFqiX3mJjUM63QAEAIfkECQoAAQAsAgACAAUACQAAAgqMARaol95iY9AUACH5BAkKAAEALAIAAgAFAAUAAAIHjAEWqJeuCgAh+QQJCgABACwFAAIAAgACAAACAoRRADs=" style="width: 32px; height: 32px;" /><span class="ms-accentText" style="font-size: 36px;">' + TaxonomyPickerConsts.WORKING_ON_IT + '</span></div></div></div>');
-                $('body').append(this._waitingDlg);
+                this._waitingDlg = jQuery('<div class="cam-taxpicker-waiting"><div class="cam-taxpicker-waiting-overlay"></div><div class="cam-taxpicker-waiting-dlg"><div class="cam-taxpicker-waiting-dlg-inner"><img alt="" src="data:image/gif;base64,R0lGODlhEAAQAIAAAFLOQv///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQFCgABACwJAAIAAgACAAACAoRRACH5BAUKAAEALAwABQACAAIAAAIChFEAIfkEBQoAAQAsDAAJAAIAAgAAAgKEUQAh+QQFCgABACwJAAwAAgACAAACAoRRACH5BAUKAAEALAUADAACAAIAAAIChFEAIfkEBQoAAQAsAgAJAAIAAgAAAgKEUQAh+QQFCgABACwCAAUAAgACAAACAoRRACH5BAkKAAEALAIAAgAMAAwAAAINjAFne8kPo5y02ouzLQAh+QQJCgABACwCAAIADAAMAAACF4wBphvID1uCyNEZM7Ov4v1p0hGOZlAAACH5BAkKAAEALAIAAgAMAAwAAAIUjAGmG8gPW4qS2rscRPp1rH3H1BUAIfkECQoAAQAsAgACAAkADAAAAhGMAaaX64peiLJa6rCVFHdQAAAh+QQJCgABACwCAAIABQAMAAACDYwBFqiX3mJjUM63QAEAIfkECQoAAQAsAgACAAUACQAAAgqMARaol95iY9AUACH5BAkKAAEALAIAAgAFAAUAAAIHjAEWqJeuCgAh+QQJCgABACwFAAIAAgACAAACAoRRADs=" style="width: 32px; height: 32px;" /><span class="ms-accentText" style="font-size: 36px;">' + TaxonomyPickerConsts.WORKING_ON_IT + '</span></div></div></div>');
+                jQuery('body').append(this._waitingDlg);
             }
             else {
                 //remove the waiting indicator (if exists)
-                $('body').children('.cam-taxpicker-waiting').remove();
+                jQuery('body').children('.cam-taxpicker-waiting').remove();
 
                 var termListing;
 
@@ -947,41 +971,41 @@
 
                 //initialize the dialog if null
                 if (this._dialog == null) {
-                    this._dialog = $('<div class="cam-taxpicker-dialog"></div>');
-                    var dlg = $('<div class="cam-taxpicker-dialog-content"></div>');
+                    this._dialog = jQuery('<div class="cam-taxpicker-dialog"></div>');
+                    var dlg = jQuery('<div class="cam-taxpicker-dialog-content"></div>');
 
                     //build dialog header with button
-                    var dlgHeader = $('<div class="cam-taxpicker-dialog-content-header"><h1 class="cam-taxpicker-dialog-content-header-title">' + TaxonomyPickerConsts.DIALOG_HEADER + this.TermSet.Name + '</h1></div>');
-                    this._dlgCloseButton = $('<div class="cam-taxpicker-dialog-content-close"></div>');
+                    var dlgHeader = jQuery('<div class="cam-taxpicker-dialog-content-header"><h1 class="cam-taxpicker-dialog-content-header-title">' + TaxonomyPickerConsts.DIALOG_HEADER + this.TermSet.Name + '</h1></div>');
+                    this._dlgCloseButton = jQuery('<div class="cam-taxpicker-dialog-content-close"></div>');
                     dlgHeader.append(this._dlgCloseButton);
                     dlg.append(dlgHeader);
 
                     //build dialog body
-                    var dlgSubheader = $('<div class="cam-taxpicker-dialog-content-subheader"><img class="cam-taxpicker-dialog-content-subheader-img" src="../styles/images/EMMDoubleTag.png" alt="" /></div>');
-                    this._dlgAddNewTermButton = $('<a style="cursor: pointer;">' + TaxonomyPickerConsts.DIALOG_ADD_LINK + '</a>');
+                    var dlgSubheader = jQuery('<div class="cam-taxpicker-dialog-content-subheader"><img class="cam-taxpicker-dialog-content-subheader-img" src="../styles/images/EMMDoubleTag.png" alt="" /></div>');
+                    this._dlgAddNewTermButton = jQuery('<a style="cursor: pointer;">' + TaxonomyPickerConsts.DIALOG_ADD_LINK + '</a>');
                     if (this.TermSet.IsOpenForTermCreation) {
-                        dlgSubheader.append($('<div class="cam-taxpicker-dialog-content-subheader-title">' + TaxonomyPickerConsts.DIALOG_ADD_TITLE + '&nbsp;</div>'));
-                        dlgSubheader.append($('<div class="cam-taxpicker-dialog-content-subheader-addnew"></div>').append(this._dlgAddNewTermButton));
+                        dlgSubheader.append(jQuery('<div class="cam-taxpicker-dialog-content-subheader-title">' + TaxonomyPickerConsts.DIALOG_ADD_TITLE + '&nbsp;</div>'));
+                        dlgSubheader.append(jQuery('<div class="cam-taxpicker-dialog-content-subheader-addnew"></div>').append(this._dlgAddNewTermButton));
                     }
-                    var dlgBody = $('<div class="cam-taxpicker-dialog-content-body"></div>');
+                    var dlgBody = jQuery('<div class="cam-taxpicker-dialog-content-body"></div>');
                     dlgBody.append(dlgSubheader);
-                    var dlgBodyContainer = $('<div class="cam-taxpicker-dialog-tree-container"></div>');
+                    var dlgBodyContainer = jQuery('<div class="cam-taxpicker-dialog-tree-container"></div>');
 
                     //build the termset hierarchy
-                    dlgBodyContainer.append($('<ul id="rootNode" class="cam-taxpicker-treenode-ul root" style="height: 100%;"></ul>'));
+                    dlgBodyContainer.append(jQuery('<ul id="rootNode" class="cam-taxpicker-treenode-ul root" style="height: 100%;"></ul>'));
 
                     //build the dialog editor area
                     //TODO: convert the dlgEditor with contenteditable="true" just like the main editor (Enhancement)
-                    this._dlgEditor = $('<div class="cam-taxpicker-dialog-selection-editor" RestrictPasteToText="true" AllowMultiLines="false"></div>');
-                    this._dlgSelectButton = $('<button>' + TaxonomyPickerConsts.BUTTON_TEXT + ' >></button>');
-                    dlgBody.append(dlgBodyContainer).append($('<div class="cam-taxpicker-dialog-selection-container"></div>').append(this._dlgSelectButton).append(this._dlgEditor));
+                    this._dlgEditor = jQuery('<div class="cam-taxpicker-dialog-selection-editor" RestrictPasteToText="true" AllowMultiLines="false"></div>');
+                    this._dlgSelectButton = jQuery('<button>' + TaxonomyPickerConsts.BUTTON_TEXT + ' >></button>');
+                    dlgBody.append(dlgBodyContainer).append(jQuery('<div class="cam-taxpicker-dialog-selection-container"></div>').append(this._dlgSelectButton).append(this._dlgEditor));
                     dlg.append(dlgBody);
-                    this._dialog.empty().append($('<div class="cam-taxpicker-dialog-overlay"></div>')).append(dlg);
+                    this._dialog.empty().append(jQuery('<div class="cam-taxpicker-dialog-overlay"></div>')).append(dlg);
 
                     //add button area
-                    var dlgButtonArea = $('<div class="cam-taxpicker-dialog-button-container"></div>')
-                    this._dlgOkButton = $('<button style="float: right;">Ok</button>');
-                    this._dlgCancelButton = $('<button style="float: right;">Cancel</button>');
+                    var dlgButtonArea = jQuery('<div class="cam-taxpicker-dialog-button-container"></div>')
+                    this._dlgOkButton = jQuery('<button style="float: right;">Ok</button>');
+                    this._dlgCancelButton = jQuery('<button style="float: right;">Cancel</button>');
                     dlgBody.append(dlgButtonArea.append(this._dlgCancelButton).append(this._dlgOkButton));
 
                 }
@@ -990,7 +1014,7 @@
                 this._dlgEditor.html(this.selectedTermsToHtml());
 
                 //add the dialog to the body
-                $('body').append(this._dialog);
+                jQuery('body').append(this._dialog);
 
                 var termName = this.TermSet.Name;
 
@@ -1011,27 +1035,27 @@
                                     '</ul>' +
                                 '</div>';
 
-                    that._dlgCurrTermNode = $("#currNode");
+                    that._dlgCurrTermNode = jQuery("#currNode");
                 });
 
 
                 //wire events all the dialog events
-                $('.cam-taxpicker-expander').click(function () {
+                jQuery('.cam-taxpicker-expander').click(function () {
                     //toggle tree node
-                    if ($(this).hasClass('expanded')) {
-                        $(this).removeClass('expanded');
-                        $(this).addClass('collapsed');
-                        $(this).parent().next().hide();
+                    if (jQuery(this).hasClass('expanded')) {
+                        jQuery(this).removeClass('expanded');
+                        jQuery(this).addClass('collapsed');
+                        jQuery(this).parent().next().hide();
                     }
-                    else if ($(this).hasClass('collapsed')) {
-                        $(this).removeClass('collapsed');
-                        $(this).addClass('expanded');
-                        $(this).parent().next().show();
+                    else if (jQuery(this).hasClass('collapsed')) {
+                        jQuery(this).removeClass('collapsed');
+                        jQuery(this).addClass('expanded');
+                        jQuery(this).parent().next().show();
                     }
                 });
 
-                $('.cam-taxpicker-treenode-title').click(Function.createDelegate(this, this.termNodeClicked));
-                $('.cam-taxpicker-treenode-title').dblclick(Function.createDelegate(this, this.termNodeDoubleClicked));
+                jQuery('.cam-taxpicker-treenode-title').click(Function.createDelegate(this, this.termNodeClicked));
+                jQuery('.cam-taxpicker-treenode-title').dblclick(Function.createDelegate(this, this.termNodeDoubleClicked));
                 this._dlgSelectButton.click(Function.createDelegate(this, this.dialogSelectButtonClicked));
                 this._dlgCloseButton.click(Function.createDelegate(this, this.dialogCancelClicked));
                 this._dlgOkButton.click(Function.createDelegate(this, this.dialogOkClicked));
@@ -1042,7 +1066,7 @@
         //closes the picker dialog
         closePickerDialog: function (event) {
             //remove the picker dialog from the body
-            $('body').children('.cam-taxpicker-dialog').remove();
+            jQuery('body').children('.cam-taxpicker-dialog').remove();
         },
         //adds a new term to the end of this._selectedTerms
         pushSelectedTerm: function (term) {
@@ -1086,6 +1110,15 @@
             }
             return termsHtml;
         },
+        //converts this._selectedTerms to array for external applications use.
+        selectedTermNamesToArray: function () {
+            var termsArray = [];
+            for (var i = 0; i < this._selectedTerms.length; i++) {
+                var e = this._selectedTerms[i];
+                termsArray.push(e.Name);
+            }
+            return termsArray;
+        },
         //trim suggestions based on existing selections
         trimSuggestions: function (suggestions) {
             var trimmedSuggestions = new Array();
@@ -1118,7 +1151,7 @@
 
         for (var i = 0, len = termList.length; i < len; i++) {
             var term = termList[i];
-            var deferred = $.Deferred();
+            var deferred = jQuery.Deferred();
             defs.push(deferred);
 
             var addlClass = (term.Children.length > 0) ? 'collapsed' : '';
@@ -1149,7 +1182,7 @@
             deferred.resolve();
         }
 
-        $.when($, defs).done(function () {
+        jQuery.when(jQuery, defs).done(function () {
             if (cb) {
                 cb(outHtml)
             }
@@ -1197,7 +1230,7 @@
     }
 
     //extends jquery to support taxpicker function
-    $.fn.taxpicker = function (options, ctx, changeCallback) {
+    jQuery.fn.taxpicker = function (options, ctx, changeCallback) {
         //TODO: display error message when the control isn't bound correctly????
 
         //verify context
@@ -1214,10 +1247,10 @@
 
         //set spcontext
         spContext = ctx;
-        if ($.taxpicker == undefined)
-            $.taxpicker = [];
+        if (jQuery.taxpicker == undefined)
+            jQuery.taxpicker = [];
 
         //create new TaxonomyPicker instance and increment index (in case we need to re-reference)
-        $.taxpicker[taxIndex] = new TaxonomyPicker(this, options, ctx, changeCallback);
+        jQuery.taxpicker[taxIndex] = new TaxonomyPicker(this, options, ctx, changeCallback);
     };
 })(CAMControl || (CAMControl = {}));

--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -481,6 +481,8 @@
                 if (sel.length > 0) {
                     this._editor.blur();
                     sel.click();
+                    this._editor[0].focus();
+                    this.placeCaretAtEnd(this._editor[0]);
                     return false;
                 }
 
@@ -492,8 +494,11 @@
                 //close the suggestion panel
                 this._suggestionContainer.hide();
 
+                this._editor[0].focus();
+                this.placeCaretAtEnd(this._editor[0]);
+
                 if (keynum == 13) { // also validate on enter, we need to cancel the enter and blur
-                    this._editor.blur();
+                    //this._editor.blur();
                     return false;
                 }
             }
@@ -597,6 +602,24 @@
                 marker.parentNode.removeChild(marker);
             }
         },
+        //place the cursor at the end of the contentEditable div
+        placeCaretAtEnd: function (el) {
+		    el.focus();
+		    if (typeof window.getSelection != "undefined"
+		            && typeof document.createRange != "undefined") {
+		        var range = document.createRange();
+		        range.selectNodeContents(el);
+		        range.collapse(false);
+		        var sel = window.getSelection();
+		        sel.removeAllRanges();
+		        sel.addRange(range);
+		    } else if (typeof document.body.createTextRange != "undefined") {
+		        var textRange = document.body.createTextRange();
+		        textRange.moveToElementText(el);
+		        textRange.collapse(false);
+		        textRange.select();
+		    }
+		},
         //validates the text input into ranges and html output
         validateText: function (txt) {
             var textValidation = { html: '', ranges: [] };

--- a/Components/Core.TaxonomyPicker/README.md
+++ b/Components/Core.TaxonomyPicker/README.md
@@ -131,6 +131,7 @@ The first parameter of the Taxonomy Picker sets the options for the control. The
 | isMulti | Boolean indicating if taxonomy picker support multiple value |
 | isReadOnly | Boolean indicating if the taxonomy picker is rendered in read only mode |
 | allowFillIn | Boolean indicating if the control allows fill=ins (Open TermSets only) |
+| enterFillIn | Boolean indicating if the control allows fill=ins using enter or tab instead the button (Open TermSets only) |
 | termSetId | the GUID of the TermSet to bind against (available from Term Mgmt) |
 | useHashtags | Boolean indicating if the default hashtags TermSet should be used |
 | useKeyword | Boolean indicating if the default keywords TermSet should be used |


### PR DESCRIPTION
Changes:
 - Change $ by jQuery to avoid some conflicts in SharePoint pages
 - enterFillIn: Boolean indicating if the control allows fill=ins using enter or tab instead the button (like Delve) - note that this addition doesn't call to the server to add the new term. It just add in the hidden input that is used when we click on save button (which is good in terms of performance).
 - selectedTermNamesToArray: converts this._selectedTerms to array for external applications use. 
 - placeCaretAtEnd: place the cursor at the end of the contentEditable div
 - Solved the bug with the cursor when term selected.
- Hide suggestions panel when we don't have suggestions.