### PR TITLE
JSSIG - Added configuration objects to the global PnP namespace

### DIFF
--- a/Libraries/Core.JavaScript/src/configuration/configuration.ts
+++ b/Libraries/Core.JavaScript/src/configuration/configuration.ts
@@ -2,6 +2,9 @@
 
 import * as Collections from "../collections/collections";
 import {Promise} from "es6-promise";
+import * as providers from "./providers/providers";
+
+export let Providers = providers;
 
 export interface IConfigurationProvider {
     getConfiguration(): Promise<Collections.ITypedHash<string>>;

--- a/Libraries/Core.JavaScript/src/configuration/providers/cachingConfigurationProvider.ts
+++ b/Libraries/Core.JavaScript/src/configuration/providers/cachingConfigurationProvider.ts
@@ -1,5 +1,5 @@
-import {IConfigurationProvider} from "configuration";
-import {ITypedHash} from "../collections/collections";
+import {IConfigurationProvider} from "../configuration";
+import {ITypedHash} from "../../collections/collections";
 import * as storage from "../../utils/storage";
 import {Promise} from "es6-promise";
 

--- a/Libraries/Core.JavaScript/src/configuration/providers/providers.ts
+++ b/Libraries/Core.JavaScript/src/configuration/providers/providers.ts
@@ -1,0 +1,5 @@
+import {default as cachingConfigurationProvider} from "./cachingConfigurationProvider";
+import {default as spListConfigurationProvider} from "./spListConfigurationProvider";
+
+export let CachingConfigurationProvider = cachingConfigurationProvider;
+export let SPListConfigurationProvider = spListConfigurationProvider;

--- a/Libraries/Core.JavaScript/src/configuration/providers/spListConfigurationProvider.ts
+++ b/Libraries/Core.JavaScript/src/configuration/providers/spListConfigurationProvider.ts
@@ -1,5 +1,5 @@
-import {IConfigurationProvider} from "configuration";
-import {ITypedHash} from "../collections/collections";
+import {IConfigurationProvider} from "../configuration";
+import {ITypedHash} from "../../collections/collections";
 import {Promise} from "es6-promise";
 import { default as CachingConfigurationProvider } from "./cachingConfigurationProvider";
 import * as ajax from "../../Utils/Ajax";

--- a/Libraries/Core.JavaScript/src/pnp.ts
+++ b/Libraries/Core.JavaScript/src/pnp.ts
@@ -3,6 +3,7 @@
 import * as Util from "./Utils/Util";
 import { SharePoint } from "./SharePoint/SharePoint";
 import { PnPClientStorage } from "./Utils/Storage";
+import * as Configuration from "./configuration/configuration";
 
 /**
  * Root class of the Patterns and Practices namespace, provides an entry point to the library
@@ -22,6 +23,11 @@ class PnP {
      * Provides access to local and session storage through
      */
     public static storage: PnPClientStorage = new PnPClientStorage();
+
+    /**
+     * Configuration 
+     */
+    public static configuration = Configuration;
 }
 
 export = PnP;


### PR DESCRIPTION
Related to issue #1328: Port over configuration data

Added configuration and related providers to the global PnP object graph in order to have them included also in the packaged and minimized (``gulp package``) output. Also fixed some import paths that were not working during the packaging step. 