### PR TITLE
List items endpoint for Fluent API wrapper

### DIFF
--- a/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/items/items.test.ts
+++ b/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/items/items.test.ts
@@ -1,0 +1,24 @@
+"use strict";
+
+import { expect } from "chai";
+import { Items } from "./Items";
+
+describe("Items", () => {
+    it("Should be an object", () => {
+        let items = new Items(["_api/web"]);
+        expect(items).to.be.a("object");
+    });
+    describe("url", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/Items", () => {
+            let items = new Items(["_api/web/lists/getByTitle('Tasks')"]);
+            expect(items.url()).to.equal("_api/web/lists/getByTitle('Tasks')/Items");
+        });
+    });
+    describe("getById", () => {
+        it("Should return _api/web/lists/getByTitle('Tasks')/Items(1)", () => {
+            let items = new Items(["_api/web/lists/getByTitle('Tasks')"]);
+            let item = items.getById(1);
+            expect(item.url()).to.equal("_api/web/lists/getByTitle('Tasks')/Items(1)");
+        });
+    });
+});

--- a/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/items/items.ts
+++ b/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/items/items.ts
@@ -1,0 +1,15 @@
+"use strict";
+
+/// <reference path="..\..\..\..\typings\main.d.ts" />
+
+import { Queryable } from "../../../Queryable";
+
+export class Items extends Queryable {
+    constructor(url: Array<string>) {
+        super(url, "/Items");
+    }
+    public getById(id: number) {
+        this._url.push(`(${id})`);
+        return this;
+    }
+}

--- a/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/lists.ts
+++ b/Libraries/Core.JavaScript/src/sharepoint/rest/web/lists/lists.ts
@@ -3,6 +3,7 @@
 /// <reference path="..\..\..\typings\main.d.ts" />
 
 import { Queryable } from "../../Queryable";
+import { Items } from "./Items/Items";
 
 export class Lists extends Queryable {
     constructor(url: Array<string>) {
@@ -11,11 +12,11 @@ export class Lists extends Queryable {
 
     public getByTitle(title: string) {
         this._url.push(`/getByTitle('${title}')`);
-        return this;
+        return jQuery.extend(this, { items: new Items(this._url) });
     }
 
     public getById(id: string) {
         this._url.push(`('${id}')`);
-        return this;
+        return jQuery.extend(this, { items: new Items(this._url) });
     }
 }

--- a/Libraries/Core.JavaScript/src/sharepoint/sharepoint.ts
+++ b/Libraries/Core.JavaScript/src/sharepoint/sharepoint.ts
@@ -8,9 +8,9 @@ export class SharePoint {
      * The REST base class for SharePoint
      */
     public rest = new Rest();
-	
+
 	 /**
      * The Provisioning base class for SharePoint
      */
-	public provisioning: Provisioning = new Provisioning();
+     public provisioning: Provisioning = new Provisioning();
 }


### PR DESCRIPTION
Initial commit for List Items for Fluent API Wrapper.

getById and getByTitle of the Lists class extends the return with the Items class.

We should include typings to be able to get intellisense for ...getByTitle('Tasks').Items.

If we include Items as property/function initially, we need to throw an expection if there's no list context.

cc @okms