### PR TITLE
Update CustomInjectedJS.js

### DIFF
--- a/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
+++ b/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
@@ -8,7 +8,7 @@ function SubSiteOverride_Inject() {
     // Run injection only for site content
     if ((window.location.href.toLowerCase().indexOf("viewlsts.aspx") > -1 && window.location.href.toLowerCase().indexOf("_layouts/15") > -1))
     {
-        SubSiteOverride_OverrideLinkToAppUrl();
+        _spBodyOnLoadFunctionNames.push(SubSiteOverride_OverrideLinkToAppUrl());
     }
 }
 

--- a/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
+++ b/Samples/Provisioning.SubSiteCreationApp/Provisioning.SubSiteCreationAppWeb/Resources/CustomInjectedJS.js
@@ -8,7 +8,7 @@ function SubSiteOverride_Inject() {
     // Run injection only for site content
     if ((window.location.href.toLowerCase().indexOf("viewlsts.aspx") > -1 && window.location.href.toLowerCase().indexOf("_layouts/15") > -1))
     {
-        _spBodyOnLoadFunctionNames.push(SubSiteOverride_OverrideLinkToAppUrl());
+        _spBodyOnLoadFunctionNames.push('SubSiteOverride_OverrideLinkToAppUrl');
     }
 }
 


### PR DESCRIPTION
There is a small bug in the original code. When user clicks on the back button, the event handler doesn't fire and the URL is not replaced. By simply adding _spBodyOnLoadFunctionNames, the function is called after the body is loaded again and the link is replaced correctly every time.

Change:
_spBodyOnLoadFunctionNames.push('SubSiteOverride_OverrideLinkToAppUrl');