### PR TITLE
Fixes tree gets collapsed on localized parents.

### DIFF
--- a/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
+++ b/Components/Core.TaxonomyPicker/Core.TaxonomyPickerWeb/Scripts/taxonomypickercontrol.js
@@ -149,12 +149,15 @@
         //gets a term parent collection based on the path passed in (ex: World;Europe;Finland would return the Europe term)
         getTermParentCollectionByPath: function (path) {
             var term = null;
+            var termPath = null;
             var parts = path.split(';');
             var termList = this.Terms;
+
             for (var i = 0; i < parts.length - 1; i++) {
                 for (var j = 0; j < termList.length; j++) {
-                    if (parts[i] == termList[j].Name) {
-                        term = termList[j];
+                    term = termList[j];
+                    termPath = term.PathOfTerm.split(';')
+                    if (termPath.length > 0 && parts[i] == termPath[termPath.length - 1]) {
                         termList = term.Children;
                         break;
                     }


### PR DESCRIPTION
If a localization is made on parent term, the term tree gets collapsed on that level. The Name property contains the localized label and should be replaced with last segment of PathOfTerm that contains the non localized label.