### PR TITLE
Fixes AuthenticationHelper to use AcquireTokenAsync

### DIFF
--- a/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/AuthenticationHelper.cs
+++ b/Samples/Core.UserProfiles.Sync/Core.UserProfiles.Sync/AuthenticationHelper.cs
@@ -11,39 +11,28 @@
         public static string TokenForUser;
         public const string ResourceUrl = "https://graph.windows.net";
 
-        /// <summary>
-        /// Async task to acquire token for Application.
-        /// </summary>
-        /// <returns>Async Token for application.</returns>
-        public static async Task<string> AcquireTokenAsyncForApplication()
+        public static ActiveDirectoryClient GetActiveDirectoryClientAsApplication(Guid tenantId)
         {
-            return GetTokenForApplication();
+            Uri servicePointUri = new Uri(ResourceUrl);
+            Uri serviceRoot = new Uri(servicePointUri, tenantId.ToString());
+            ActiveDirectoryClient activeDirectoryClient = new ActiveDirectoryClient(serviceRoot, GetTokenForApplicationAsync);
+            return activeDirectoryClient;
         }
 
-         public static ActiveDirectoryClient GetActiveDirectoryClientAsApplication(Guid tenantId) 
-         { 
-             Uri servicePointUri = new Uri(ResourceUrl); 
-             Uri serviceRoot = new Uri(servicePointUri, tenantId.ToString()); 
-             ActiveDirectoryClient activeDirectoryClient = new ActiveDirectoryClient(serviceRoot, 
-                 async () => await AcquireTokenAsyncForApplication()); 
-             return activeDirectoryClient; 
-         }
-
-         public static ActiveDirectoryClient GetActiveDirectoryClientAsApplication(Uri sharePointAdminUrl)
-         {
-             Uri servicePointUri = new Uri(ResourceUrl);
-             string adminRealm = TokenHelper.GetRealmFromTargetUrl(sharePointAdminUrl);
-             Uri serviceRoot = new Uri(servicePointUri, adminRealm);
-             ActiveDirectoryClient activeDirectoryClient = new ActiveDirectoryClient(serviceRoot,
-                 async () => await AcquireTokenAsyncForApplication());
-             return activeDirectoryClient;
-         } 
+        public static ActiveDirectoryClient GetActiveDirectoryClientAsApplication(Uri sharePointAdminUrl)
+        {
+            Uri servicePointUri = new Uri(ResourceUrl);
+            string adminRealm = TokenHelper.GetRealmFromTargetUrl(sharePointAdminUrl);
+            Uri serviceRoot = new Uri(servicePointUri, adminRealm);
+            ActiveDirectoryClient activeDirectoryClient = new ActiveDirectoryClient(serviceRoot, GetTokenForApplicationAsync);
+            return activeDirectoryClient;
+        }
 
         /// <summary>
         /// Get Token for Application.
         /// </summary>
         /// <returns>Token for application.</returns>
-        public static string GetTokenForApplication()
+        public static async Task<string> GetTokenForApplicationAsync()
         {
             var authenticationUrl = "https://login.windows.net/" + ConfigurationManager.AppSettings["TenantUpnDomain"];
             AuthenticationContext authenticationContext = new AuthenticationContext(authenticationUrl, false);
@@ -53,7 +42,7 @@
                 ConfigurationManager.AppSettings["ClientId"],
                 ConfigurationManager.AppSettings["ClientSecret"]);
 
-            AuthenticationResult authenticationResult = authenticationContext.AcquireToken(ResourceUrl,
+            AuthenticationResult authenticationResult = await authenticationContext.AcquireTokenAsync(ResourceUrl,
                 clientCred);
             string token = authenticationResult.AccessToken;
             return token;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| New sample?      | no
| Related issues?  | fixes #1445 

#### What's in this Pull Request?

Fixes #1445 by changing `AuthenticationHelper `on the Core.UserProfiles.Sync sample to use `AcquireTokenAsync` instead of `AcquireToken`.
