### PR TITLE
Force sp-pnp-js package version to 1.0.4

### DIFF
--- a/Solutions/Business.O365StarterIntranet/App/package.json
+++ b/Solutions/Business.O365StarterIntranet/App/package.json
@@ -51,7 +51,7 @@
     "node-fetch": "^1.5.3",
     "office-ui-fabric": "^2.6.1",
     "pubsub-js": "^1.5.3",
-    "sp-pnp-js": "^1.0.4",
+    "sp-pnp-js": "1.0.4",
     "sprintf-js": "^1.0.3",
     "trunk8": "0.0.1",
     "whatwg-fetch": "^1.0.0"


### PR DESCRIPTION
Bug fix

Forced the 1.0.4 version for the sp-pnp-js package. Running "npm install" with the "^" caret character, will update to the 1.0.5 version causing issues with TypeScript versions. See [https://github.com/OfficeDev/PnP/issues/1549](https://github.com/OfficeDev/PnP/issues/1549) issue.
